### PR TITLE
Cooldowns from main script will go directly to sub

### DIFF
--- a/GottaGoFast.ahk
+++ b/GottaGoFast.ahk
@@ -100,7 +100,7 @@ if not A_IsAdmin
 		global OnVendor:=False
 
 	;Hotkeys
-		global hotkeyPopFlasks
+		global hotkeyAutoQuicksilver
 ; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ; Standard ini read
 ; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -136,7 +136,6 @@ if not A_IsAdmin
 		IniRead, QuicksilverSlot4, settings.ini, Quicksilver, QuicksilverSlot4
 		IniRead, QuicksilverSlot5, settings.ini, Quicksilver, QuicksilverSlot5
 		;Hotkeys
-		IniRead, hotkeyPopFlasks, settings.ini, hotkeys, PopFlasks
 		IniRead, hotkeyAutoQuicksilver, settings.ini, hotkeys, AutoQuicksilver
 		} 
 ; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -182,14 +181,12 @@ IfWinExist, ahk_group POEGameGroup
 		WinActivate, ahk_group POEGameGroup
 	}
 
-If hotkeyPopFlasks
-	hotkey,~%hotkeyPopFlasks%, PopFlasksCommand, On
 If hotkeyAutoQuicksilver
 	hotkey,%hotkeyAutoQuicksilver%, AutoQuicksilverCommand, On
 
 
 ;Pop all flasks
-PopFlasksCommand:
+PopFlaskCooldowns(){
 	If (PopFlaskRespectCD)
 		TriggerFlaskCD(11111)
 	Else {
@@ -205,40 +202,10 @@ PopFlasksCommand:
 		settimer, TimmerFlask5, %CoolDownFlask5%
 		}
 	return
+	}
 
 ~#Escape::
 	ExitApp
-
-;Passthrough for manual activation
-	; pass-thru and start timer for flask 1
-	~1::
-		OnCoolDown[1]:=1 
-		settimer, TimmerFlask1, %CoolDownFlask1%
-		return
-
-	; pass-thru and start timer for flask 2
-	~2::
-		OnCoolDown[2]:=1 
-		settimer, TimmerFlask2, %CoolDownFlask2%
-		return
-
-	; pass-thru and start timer for flask 3
-	~3::
-		OnCoolDown[3]:=1 
-		settimer, TimmerFlask3, %CoolDownFlask3%
-		return
-
-	; pass-thru and start timer for flask 4
-	~4::
-		OnCoolDown[4]:=1 
-		settimer, TimmerFlask4, %CoolDownFlask4%
-		return
-
-	; pass-thru and start timer for flask 5
-	~5::
-		OnCoolDown[5]:=1 
-		settimer, TimmerFlask5, %CoolDownFlask5%
-		return
 
 ;Toggle Auto-Quick
 AutoQuicksilverCommand:
@@ -250,11 +217,42 @@ AutoQuicksilverCommand:
     }
 	GuiUpdate()
 	return
+; Receive Messages from other scripts
+; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 MsgMonitor(wParam, lParam, msg)
 	{
 	critical
     If (wParam=1)
 		ReadFromFile()
+	Else If (wParam=2)
+		PopFlaskCooldowns()
+	Else If (wParam=3) {
+		If (lParam=1){
+			OnCoolDown[1]:=1 
+			settimer, TimmerFlask1, %CoolDownFlask1%
+			return
+			}		
+		If (lParam=2){
+			OnCoolDown[2]:=1 
+			settimer, TimmerFlask2, %CoolDownFlask2%
+			return
+			}		
+		If (lParam=3){
+			OnCoolDown[3]:=1 
+			settimer, TimmerFlask3, %CoolDownFlask3%
+			return
+			}		
+		If (lParam=4){
+			OnCoolDown[4]:=1 
+			settimer, TimmerFlask4, %CoolDownFlask4%
+			return
+			}		
+		If (lParam=5){
+			OnCoolDown[5]:=1 
+			settimer, TimmerFlask5, %CoolDownFlask5%
+			return
+			}		
+	}
 	Return
 	}
 PoEWindowCheck(){

--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -20,6 +20,8 @@
 	FileEncoding , UTF-8
 	SendMode Input
 	StringCaseSense, On ; Match strings with case.
+	; Create a container for the sub-script
+	Global scriptGottaGoFast := "GottaGoFast.ahk ahk_class AutoHotkey"
 	; Create Executable group for gameHotkey, IfWinActive
 	global POEGameArr := ["PathOfExile.exe", "PathOfExile_x64.exe", "PathOfExileSteam.exe", "PathOfExile_x64Steam.exe", "PathOfExile_KG.exe", "PathOfExile_x64_KG.exe"]
 	for n, exe in POEGameArr {
@@ -881,7 +883,7 @@
 	Gui Add, Checkbox, gUpdateExtra	vShowOnStart                         	          	, Show GUI on startup?
 	Gui Add, Checkbox, gUpdateExtra	vSteam                         	          	, Are you using Steam?
 	Gui Add, Checkbox, gUpdateExtra	vHighBits                         	          	, Are you running 64 bit?
-	Gui Add, DropDownList, gUpdateResolutionScale	vResolutionScale   ChooseString%ResolutionScale%      w80               	    , Standard|UltraWide|QHD
+	Gui Add, DropDownList, gUpdateResolutionScale	vResolutionScale   ChooseString%ResolutionScale%      w80               	    , Standard|UltraWide
 	Gui Add, Text, 			x+8 y+-18							 							, Aspect Ratio
 	Gui, Add, DropDownList, R5 gUpdateExtra vLatency Choose%Latency% w30 x+-149 y+10,  1|2|3
 	Gui Add, Text, 										x+10 y+-18							, Adjust Latency
@@ -1552,30 +1554,35 @@
 	~1::
 		OnCoolDown[1]:=1 
 		settimer, TimmerFlask1, %CoolDownFlask1%
+		SendMSG(3, 1, scriptGottaGoFast)
 		return
 
 	; pass-thru and start timer for flask 2
 	~2::
 		OnCoolDown[2]:=1 
 		settimer, TimmerFlask2, %CoolDownFlask2%
+		SendMSG(3, 2, scriptGottaGoFast)
 		return
 
 	; pass-thru and start timer for flask 3
 	~3::
 		OnCoolDown[3]:=1 
 		settimer, TimmerFlask3, %CoolDownFlask3%
+		SendMSG(3, 3, scriptGottaGoFast)
 		return
 
 	; pass-thru and start timer for flask 4
 	~4::
 		OnCoolDown[4]:=1 
 		settimer, TimmerFlask4, %CoolDownFlask4%
+		SendMSG(3, 4, scriptGottaGoFast)
 		return
 
 	; pass-thru and start timer for flask 5
 	~5::
 		OnCoolDown[5]:=1 
 		settimer, TimmerFlask5, %CoolDownFlask5%
+		SendMSG(3, 5, scriptGottaGoFast)
 		return
 
 ; Move to # stash hotkeys
@@ -2343,7 +2350,7 @@ Rescale(){
 	return
 	}
 
-;Toggle Auto-Quit
+; Toggle Auto-Quit
 ; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AutoQuit(){
 	AutoQuitCommand:
@@ -2356,7 +2363,7 @@ AutoQuit(){
 	return
 	}
 
-;Toggle Auto-Pot
+; Toggle Auto-Pot
 ; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 AutoFlask(){
 	AutoFlaskCommand:	
@@ -2477,26 +2484,31 @@ PopFlasks(){
 	Else {
 		Send 1
 		OnCoolDown[1]:=1 
+		SendMSG(3, 1, scriptGottaGoFast)
 		CoolDown:=CoolDownFlask1
 		settimer, TimmerFlask1, %CoolDown%
 		RandomSleep(-99,99)
 		Send 4
 		OnCoolDown[4]:=1 
 		CoolDown:=CoolDownFlask4
+		SendMSG(3, 4, scriptGottaGoFast)
 		settimer, TimmerFlask4, %CoolDown%
 		RandomSleep(-99,99)
 		Send 3
 		OnCoolDown[3]:=1 
+		SendMSG(3, 3, scriptGottaGoFast)
 		CoolDown:=CoolDownFlask3
 		settimer, TimmerFlask3, %CoolDown%
 		RandomSleep(-99,99)
 		Send 2
 		OnCoolDown[2]:=1 
+		SendMSG(3, 2, scriptGottaGoFast)
 		CoolDown:=CoolDownFlask2
 		settimer, TimmerFlask2, %CoolDown%
 		RandomSleep(-99,99)
 		Send 5
 		OnCoolDown[5]:=1 
+		SendMSG(3, 5, scriptGottaGoFast)
 		CoolDown:=CoolDownFlask5
 		settimer, TimmerFlask5, %CoolDown%
 	}
@@ -2525,6 +2537,7 @@ LogoutCommand(){
 	}
 
 ; Main function of the LutBot logout method
+; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 logout(executable){
 	global  GetTable, SetEntry, EnumProcesses, OpenProcessToken, LookupPrivilegeValue, AdjustTokenPrivileges, loadedPsapi
 	Critical
@@ -3197,6 +3210,14 @@ PoEWindowCheck(){
 		}
 	Return
 	}
+; Send one or two digits to a sub-script 
+; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SendMSG(wParam:=0, lParam:=0, script:=""){
+	DetectHiddenWindows On
+	if WinExist(script) 
+		PostMessage, 0x5555, wParam, lParam  ; The message is sent  to the "last found window" due to WinExist() above.
+	DetectHiddenWindows Off  ; Must not be turned off until after PostMessage.
+	}
 ; Pixelcheck for different parts of the screen to see what your status is in game. 
 ; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GuiStatus(Fetch:=""){
@@ -3568,6 +3589,7 @@ TriggerFlask(Trigger){
 		if (FLVal > 0) {
 			if (OnCoolDown[FL]=0) {
 				send %FL%
+				SendMSG(3, FL, scriptGottaGoFast)
 				OnCoolDown[FL]:=1 
 				CoolDown:=CoolDownFlask%FL%
 				settimer, TimmerFlask%FL%, %CoolDown%
@@ -4061,10 +4083,7 @@ Clamp( Val, Min, Max) {
 			{
 			WinActivate, ahk_group POEGameGroup
 			}
-		DetectHiddenWindows On
-		if WinExist("GottaGoFast.ahk ahk_class AutoHotkey")
-			PostMessage, 0x5555, 1  ; The message is sent  to the "last found window" due to WinExist() above.
-		DetectHiddenWindows Off  ; Must not be turned off until after PostMessage.
+		SendMSG(1, , scriptGottaGoFast)
 		return  
 		}
 


### PR DESCRIPTION
Now that I have a method of interaction with subscript, I have removed
duplicate functions from the subscript and replaced them with similar
code that runs on receiving a message instead.

Esentially, it was putting the flasks on two slightly different timers
sometimes. Now it will go 1:1 with each other. Except when the subscript
is triggering the CD, I couldnt get it to work going from the subscript
back to the main. That will be something to possibly figure out later.

Other things to note:
I found a way to improve the Quicksilver flasks, they are not being put
into a list of available cooldowns, and he was using a long sleep
instead of a timer. I think removing the sleep and making it fill a list
of ready to pop flasks. then another section will only run if there are
items in that array, and the other portion will stop filling the list.
That way it can keep checking for the next flask to pop and you holding
the key, and consistantly moving from one flask to the next without
skipping them. Will look at syntax of adding and removing into array.