### PR TITLE
Fix savedir discovery in CLF editor

### DIFF
--- a/data/LootFilter.ahk
+++ b/data/LootFilter.ahk
@@ -1,7 +1,7 @@
 ﻿#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
     ; #Warn  ; The rest of this area is for global settings
     SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
-    SaveDir := RTrim(A_ScriptDir, "\data") "\save"
+    SaveDir := RegExReplace(A_ScriptDir, "\\data$", "\\save")
     SetWorkingDir %SaveDir%
 
     Global xpos, ypos, Maxed


### PR DESCRIPTION
The `RTrim` function removes any character in the second string that is at the end of the first; `RTrim(A_ScriptDir, "\data")` removes any d, a, or t character at the end, so `...\WingmanReloaded\data` becomes `...\WingmanReloade`.

This fixes that to replace the string, anchored appropriately.