### PR TITLE
Remove-Implicit-From-Item-Parser

### DIFF
--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -3991,6 +3991,7 @@ Return
         {
           if InStr(A_LoopField, "(implicit)")
           {
+            Affix.Implicit := A_LoopField
             If (captureLines < 1) 
             {
               imp := RegExReplace(StrSplit(A_LoopField, "(implicit)", " ")[1], "i)([-.0-9]+)", "#")
@@ -4018,6 +4019,7 @@ Return
                 ExtraSection := 1
               }
             }
+            Continue
           }
           Else
           {


### PR DESCRIPTION
I create a Pull Request as will impact several CLF. TBH when i use clf, implicts fuck all calculation with resist/spelldmg as we cant remove it from Pseudo