### PR TITLE
Improve price error notification

### DIFF
--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -5109,7 +5109,7 @@
         {
           If (A_TickCount - WarnedError > 30000 )
           {
-            Notify(PriceObj.error_msg,"",0,,2)
+            Notify(PriceObj.error_msg, "", 10)
             WarnedError := A_TickCount
           }
           return


### PR DESCRIPTION
Replace the 'must be clicked' notification with one that automatically dismisses after 10 seconds