### PR TITLE
Return when attempting to price normal/magic items

### DIFF
--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -5104,6 +5104,8 @@
       }
       If !FoundMatch
       {
+        if (Item.Prop.Rarity_Digit <= 1)
+          return
         PriceObj := TradeFunc_DoPoePricesRequest(Clip_Contents, "")
         if (PriceObj.error)
         {

--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -5104,7 +5104,7 @@
       }
       If !FoundMatch
       {
-        if (Item.Prop.Rarity_Digit <= 1)
+        if (Item.Prop.Rarity_Digit <= 2)
           return
         PriceObj := TradeFunc_DoPoePricesRequest(Clip_Contents, "")
         if (PriceObj.error)


### PR DESCRIPTION
Trying to price check normal/magic items results in error "We've disabled non-rare api calls".