### PR TITLE
Add bricked maps to inventory sorting

### DIFF
--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -494,6 +494,8 @@
       StashTabYesFlaskQuality = Enable to send Quality Flask items to the assigned tab on the left
       StashTabLinked = Assign the Stash tab for 6 or 5 Linked items
       StashTabYesLinked = Enable to send 6 or 5 Linked items to the assigned tab on the left
+      StashTabBrickedMaps = Assign the Stash tab for maps that have unwanted mods on them
+      StashTabYesBrickedMaps = Enable to send maps that have unwanted mods on them to the assigned tab on the left
       StashTabUniqueDump = Assign the Stash tab for Unique items`rIf Collection is enabled, this will be where overflow goes
       StashTabYesUniqueDump = Enable to send Unique items to the assigned tab on the left`rIf Collection is enabled, this will be where overflow goes
       StashTabUniqueRing = Assign the Stash tab for Unique Ring items`rIf Collection is enabled, this will be where overflow rings go
@@ -833,6 +835,7 @@
     Global StashTabGemQuality := 1
     Global StashTabFlaskQuality := 1
     Global StashTabLinked := 1
+    Global StashTabBrickedMaps := 1
     Global StashTabInfluencedItem := 1
     Global StashTabCrafting := 1
     Global StashTabProphecy := 1
@@ -866,6 +869,7 @@
     Global StashTabYesGemQuality := 1
     Global StashTabYesFlaskQuality := 1
     Global StashTabYesLinked := 1
+    Global StashTabYesBrickedMaps := 1
     Global StashTabYesInfluencedItem := 1
     Global StashTabYesCrafting := 1
     Global StashTabYesProphecy := 1
@@ -5367,6 +5371,7 @@ Return
       IniRead, StashTabGemQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGemQuality, 1
       IniRead, StashTabFlaskQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskQuality, 1
       IniRead, StashTabLinked, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabLinked, 1
+      IniRead, StashTabBrickedMaps, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBrickedMaps, 1
       IniRead, StashTabUnique, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUnique, 1
       IniRead, StashTabUniqueRing, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUniqueRing, 1
       IniRead, StashTabUniqueDump, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUniqueDump, 1
@@ -5413,6 +5418,7 @@ Return
       IniRead, StashTabYesCrafting, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesCrafting, 1
       IniRead, StashTabYesProphecy, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesProphecy, 1
       IniRead, StashTabYesVeiled, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesVeiled, 1
+      IniRead, StashTabYesBrickedMaps, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesBrickedMaps, 1
       IniRead, StashTabYesDump, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesDump, 0
       IniRead, StashDumpInTrial, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashDumpInTrial, 0
       IniRead, StashTabPredictive, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabPredictive, 1
@@ -6064,6 +6070,7 @@ Return
       IniWrite, %StashTabGemQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGemQuality
       IniWrite, %StashTabFlaskQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskQuality
       IniWrite, %StashTabLinked%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabLinked
+      IniWrite, %StashTabBrickedMaps%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBrickedMaps
       IniWrite, %StashTabUnique%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUnique
       IniWrite, %StashTabUniqueRing%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUniqueRing
       IniWrite, %StashTabUniqueDump%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUniqueDump
@@ -6103,6 +6110,7 @@ Return
       IniWrite, %StashTabYesCrafting%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesCrafting
       IniWrite, %StashTabYesProphecy%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesProphecy
       IniWrite, %StashTabYesVeiled%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesVeiled
+      IniWrite, %StashTabYesBrickedMaps%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesBrickedMaps
       IniWrite, %StashTabYesDump%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesDump
       IniWrite, %StashDumpInTrial%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashDumpInTrial
       IniWrite, %StashTabPredictive%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabPredictive

--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -4337,22 +4337,7 @@ Return
     antp := Item.Prop.Map_PackSize
     antq := Item.Prop.Map_Quantity
     ;MFAProjectiles,MDExtraPhysicalDamage,MICSC,MSCAT
-    While ( (Item.Affix["Monsters have #% chance to Avoid Elemental Ailments"] && AvoidAilments) 
-    || (Item.Affix["Monsters have a #% chance to avoid Poison, Blind, and Bleeding"] && AvoidPBB) 
-    || (Item.Affix["Monsters reflect #% of Elemental Damage"] && ElementalReflect) 
-    || (Item.Affix["Monsters reflect #% of Physical Damage"] && PhysicalReflect) 
-    || (Item.Affix["Players cannot Regenerate Life, Mana or Energy Shield"] && NoRegen) 
-    || (Item.Affix["Cannot Leech Life from Monsters"] && NoLeech)
-    || (Item.Affix["-#% maximum Player Resistances"] && MinusMPR)
-    || (Item.Affix["Monsters fire # additional Projectiles"] && MFAProjectiles)
-    || (Item.Affix["Monsters deal #% extra Physical Damage as Fire"] && MDExtraPhysicalDamage)
-    || (Item.Affix["Monsters deal #% extra Physical Damage as Cold"] && MDExtraPhysicalDamage)
-    || (Item.Affix["Monsters deal #% extra Physical Damage as Lightning"] && MDExtraPhysicalDamage)
-    || (Item.Affix["Monsters have #% increased Critical Strike Chance"] && MICSC)
-    || (Item.Affix["Monsters' skills Chain # additional times"] && MSCAT)
-    || (Item.Affix["Players have #% less Recovery Rate of Life and Energy Shield"] && LRRLES)
-    || (Item.Affix["Player chance to Dodge is Unlucky"] && PCDodgeUnlucky)
-    || (Item.Affix["Monsters have #% increased Accuracy Rating"] && MHAccuracyRating)
+    While ( BrickedMap()
     || (Item.Prop.RarityNormal) 
     || (!MMQIgnore && (Item.Prop.Map_Rarity < MMapItemRarity 
     || Item.Prop.Map_PackSize < MMapMonsterPackSize 

--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -840,29 +840,10 @@
           This.Prop.Veiled := False
         }
 
-        If ((This.Affix["Monsters have #% chance to Avoid Elemental Ailments"] && AvoidAilments) 
-        || (This.Affix["Monsters have a #% chance to avoid Poison, Blind, and Bleeding"] && AvoidPBB) 
-        || (This.Affix["Monsters reflect #% of Elemental Damage"] && ElementalReflect) 
-        || (This.Affix["Monsters reflect #% of Physical Damage"] && PhysicalReflect) 
-        || (This.Affix["Players cannot Regenerate Life, Mana or Energy Shield"] && NoRegen) 
-        || (This.Affix["Cannot Leech Life from Monsters"] && NoLeech)
-        || (This.Affix["-#% maximum Player Resistances"] && MinusMPR)
-        || (This.Affix["Monsters fire # additional Projectiles"] && MFAProjectiles)
-        || (This.Affix["Monsters deal #% extra Physical Damage as Fire"] && MDExtraPhysicalDamage)
-        || (This.Affix["Monsters deal #% extra Physical Damage as Cold"] && MDExtraPhysicalDamage)
-        || (This.Affix["Monsters deal #% extra Physical Damage as Lightning"] && MDExtraPhysicalDamage)
-        || (This.Affix["Monsters have #% increased Critical Strike Chance"] && MICSC)
-        || (This.Affix["Monsters' skills Chain # additional times"] && MSCAT)
-        || (This.Affix["Players have #% less Recovery Rate of Life and Energy Shield"] && LRRLES)
-        || (This.Affix["Player chance to Dodge is Unlucky"] && PCDodgeUnlucky)
-        || (This.Affix["Monsters have #% increased Accuracy Rating"] && MHAccuracyRating)) 
-        {
+        If (BrickedMap())
           This.Prop.IsBrickedMap := True
-        } 
-        Else 
-        {
+        Else
           This.Prop.IsBrickedMap := False
-        }
 
         ;Stack size for anything with it
         If (RegExMatch(This.Data.Blocks.Properties, "`am)^Stack Size: "rxNum "\/"rxNum ,RxMatch))
@@ -895,6 +876,31 @@
           This.Prop.TopTierColdResist := 1
         If (This.Prop.TopTierLightningResist || This.Prop.TopTierFireResist || This.Prop.TopTierColdResist || This.Prop.TopTierChaosResist)
           This.Prop.TopTierResists := (This.Prop.TopTierLightningResist?1:0) + (This.Prop.TopTierFireResist?1:0) + (This.Prop.TopTierColdResist?1:0) + (This.Prop.TopTierChaosResist?1:0)
+      }
+      BrickedMap() {
+        If ((This.Affix["Monsters have #% chance to Avoid Elemental Ailments"] && AvoidAilments) 
+        || (This.Affix["Monsters have a #% chance to avoid Poison, Blind, and Bleeding"] && AvoidPBB) 
+        || (This.Affix["Monsters reflect #% of Elemental Damage"] && ElementalReflect) 
+        || (This.Affix["Monsters reflect #% of Physical Damage"] && PhysicalReflect) 
+        || (This.Affix["Players cannot Regenerate Life, Mana or Energy Shield"] && NoRegen) 
+        || (This.Affix["Cannot Leech Life from Monsters"] && NoLeech)
+        || (This.Affix["-#% maximum Player Resistances"] && MinusMPR)
+        || (This.Affix["Monsters fire # additional Projectiles"] && MFAProjectiles)
+        || (This.Affix["Monsters deal #% extra Physical Damage as Fire"] && MDExtraPhysicalDamage)
+        || (This.Affix["Monsters deal #% extra Physical Damage as Cold"] && MDExtraPhysicalDamage)
+        || (This.Affix["Monsters deal #% extra Physical Damage as Lightning"] && MDExtraPhysicalDamage)
+        || (This.Affix["Monsters have #% increased Critical Strike Chance"] && MICSC)
+        || (This.Affix["Monsters' skills Chain # additional times"] && MSCAT)
+        || (This.Affix["Players have #% less Recovery Rate of Life and Energy Shield"] && LRRLES)
+        || (This.Affix["Player chance to Dodge is Unlucky"] && PCDodgeUnlucky)
+        || (This.Affix["Monsters have #% increased Accuracy Rating"] && MHAccuracyRating)) 
+        {
+          Return True
+        } 
+        Else 
+        {
+          return False
+        }
       }
       TopTierChaosResist(){
         If (This.Prop.ItemLevel < 30 && This.HasAffix("of the Lost"))

--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -839,6 +839,31 @@
         {
           This.Prop.Veiled := False
         }
+
+        If ((This.Affix["Monsters have #% chance to Avoid Elemental Ailments"] && AvoidAilments) 
+        || (This.Affix["Monsters have a #% chance to avoid Poison, Blind, and Bleeding"] && AvoidPBB) 
+        || (This.Affix["Monsters reflect #% of Elemental Damage"] && ElementalReflect) 
+        || (This.Affix["Monsters reflect #% of Physical Damage"] && PhysicalReflect) 
+        || (This.Affix["Players cannot Regenerate Life, Mana or Energy Shield"] && NoRegen) 
+        || (This.Affix["Cannot Leech Life from Monsters"] && NoLeech)
+        || (This.Affix["-#% maximum Player Resistances"] && MinusMPR)
+        || (This.Affix["Monsters fire # additional Projectiles"] && MFAProjectiles)
+        || (This.Affix["Monsters deal #% extra Physical Damage as Fire"] && MDExtraPhysicalDamage)
+        || (This.Affix["Monsters deal #% extra Physical Damage as Cold"] && MDExtraPhysicalDamage)
+        || (This.Affix["Monsters deal #% extra Physical Damage as Lightning"] && MDExtraPhysicalDamage)
+        || (This.Affix["Monsters have #% increased Critical Strike Chance"] && MICSC)
+        || (This.Affix["Monsters' skills Chain # additional times"] && MSCAT)
+        || (This.Affix["Players have #% less Recovery Rate of Life and Energy Shield"] && LRRLES)
+        || (This.Affix["Player chance to Dodge is Unlucky"] && PCDodgeUnlucky)
+        || (This.Affix["Monsters have #% increased Accuracy Rating"] && MHAccuracyRating)) 
+        {
+          This.Prop.IsBrickedMap := True
+        } 
+        Else 
+        {
+          This.Prop.IsBrickedMap := False
+        }
+
         ;Stack size for anything with it
         If (RegExMatch(This.Data.Blocks.Properties, "`am)^Stack Size: "rxNum "\/"rxNum ,RxMatch))
         {
@@ -2253,7 +2278,9 @@
         }
         Else If (This.Prop.IsMap && StashTabYesMap)
         {
-          If StashTabYesMap > 1
+          If ((This.Prop.IsBrickedMap) && StashTabYesBrickedMaps)
+            sendstash := StashTabBrickedMaps
+          Else If StashTabYesMap > 1
             sendstash := -2
           Else
             sendstash := StashTabMap
@@ -3051,6 +3078,13 @@
         Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
         Gui, Inventory: Add, UpDown, Range1-99 x+0 yp hp gSaveStashTabs vStashTabLinked , %StashTabLinked%
         Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesLinked Checked%StashTabYesLinked% x+5 yp+4, Enable
+
+        Gui, Inventory: Font, Bold s8 cBlack, Arial
+        Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , Bricked maps
+        Gui, Inventory: Font,
+        Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
+        Gui, Inventory: Add, UpDown, Range1-99 x+0 yp hp gSaveStashTabs vStashTabBrickedMaps , %StashTabBrickedMaps%
+        Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesBrickedMaps Checked%StashTabYesBrickedMaps% x+5 yp+4, Enable
 
         ; Third column Gui - Rare itens
 

--- a/data/WR_Prop.json
+++ b/data/WR_Prop.json
@@ -19,6 +19,7 @@
 	"Item_Height",
 	"IsMap",
 	"IsBlightedMap",
+	"IsBrickedMap",
 	"Incubator",
 	"TimelessSplinter",
 	"BreachSplinter",


### PR DESCRIPTION
Adds option to select tab to store bricked maps in (maps that conflict with crafting options)