### PR TITLE
Bricked map improvements

### DIFF
--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -4337,7 +4337,7 @@ Return
     antp := Item.Prop.Map_PackSize
     antq := Item.Prop.Map_Quantity
     ;MFAProjectiles,MDExtraPhysicalDamage,MICSC,MSCAT
-    While ( Item.Prop.IsBrickedMap
+    While ( Item.BrickedMap()
     || (Item.Prop.RarityNormal) 
     || (!MMQIgnore && (Item.Prop.Map_Rarity < MMapItemRarity 
     || Item.Prop.Map_PackSize < MMapMonsterPackSize 

--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -4337,7 +4337,7 @@ Return
     antp := Item.Prop.Map_PackSize
     antq := Item.Prop.Map_Quantity
     ;MFAProjectiles,MDExtraPhysicalDamage,MICSC,MSCAT
-    While ( Item.BrickedMap()
+    While ( Item.Prop.IsBrickedMap
     || (Item.Prop.RarityNormal) 
     || (!MMQIgnore && (Item.Prop.Map_Rarity < MMapItemRarity 
     || Item.Prop.Map_PackSize < MMapMonsterPackSize 

--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -2841,7 +2841,7 @@ Return
             ++HeistCount
             Continue
           }
-          Else If ( Item.Prop.IsMap && YesSkipMaps
+          Else If ( Item.Prop.IsMap && !Item.BrickedMap() && YesSkipMaps
           && ( (C >= YesSkipMaps && YesSkipMaps_eval = ">=") || (C <= YesSkipMaps && YesSkipMaps_eval = "<=") )
           && ((Item.Prop.RarityNormal && YesSkipMaps_normal) 
             || (Item.Prop.RarityMagic && YesSkipMaps_magic) 
@@ -4337,7 +4337,7 @@ Return
     antp := Item.Prop.Map_PackSize
     antq := Item.Prop.Map_Quantity
     ;MFAProjectiles,MDExtraPhysicalDamage,MICSC,MSCAT
-    While ( BrickedMap()
+    While ( Item.Prop.IsBrickedMap
     || (Item.Prop.RarityNormal) 
     || (!MMQIgnore && (Item.Prop.Map_Rarity < MMapItemRarity 
     || Item.Prop.Map_PackSize < MMapMonsterPackSize 

--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -840,7 +840,7 @@
           This.Prop.Veiled := False
         }
 
-        If (BrickedMap())
+        If (This.BrickedMap())
           This.Prop.IsBrickedMap := True
         Else
           This.Prop.IsBrickedMap := False
@@ -2282,11 +2282,12 @@
           Else
             sendstash := StashTabBlight
         }
+        Else If (This.Prop.IsBrickedMap && StashTabYesBrickedMaps) {
+            sendstash := StashTabBrickedMaps
+        }
         Else If (This.Prop.IsMap && StashTabYesMap)
         {
-          If ((This.Prop.IsBrickedMap) && StashTabYesBrickedMaps)
-            sendstash := StashTabBrickedMaps
-          Else If StashTabYesMap > 1
+          If StashTabYesMap > 1
             sendstash := -2
           Else
             sendstash := StashTabMap


### PR DESCRIPTION
- Make sure bricked maps are still stashed in the right tab if there isn't a tab set for normal maps.
- Override 'ignored map inventory' columns so bricked maps in those columns will still be stashed.