### PR TITLE
Bricked map improvements

### DIFF
--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -2844,7 +2844,7 @@ Return
             ++HeistCount
             Continue
           }
-          Else If ( Item.Prop.IsMap && YesSkipMaps
+          Else If ( Item.Prop.IsMap && !Item.Prop.IsBrickedMap && YesSkipMaps
           && ( (C >= YesSkipMaps && YesSkipMaps_eval = ">=") || (C <= YesSkipMaps && YesSkipMaps_eval = "<=") )
           && ((Item.Prop.RarityNormal && YesSkipMaps_normal) 
             || (Item.Prop.RarityMagic && YesSkipMaps_magic) 
@@ -4340,7 +4340,7 @@ Return
     antp := Item.Prop.Map_PackSize
     antq := Item.Prop.Map_Quantity
     ;MFAProjectiles,MDExtraPhysicalDamage,MICSC,MSCAT
-    While ( Item.BrickedMap()
+    While ( Item.Prop.IsBrickedMap
     || (Item.Prop.RarityNormal) 
     || (!MMQIgnore && (Item.Prop.Map_Rarity < MMapItemRarity 
     || Item.Prop.Map_PackSize < MMapMonsterPackSize 

--- a/PoE-Wingman.ahk
+++ b/PoE-Wingman.ahk
@@ -557,6 +557,7 @@
       stashSuffixTab9 = Assign the Stash Tab for the 9th Stash Hotkey slot
       hotkeyMainAttack = Bind the Main Attack for this Character
       hotkeySecondaryAttack = Bind the Secondary Attack for this Character
+      BrickedWhenCorrupted = Enable this if you only want to consider a map 'bricked'`rwhen it's corrupted and has an undesired mod, otherwise,`rmaps of any tier with undesired mods will be flagged as 'bricked'
       )
 
       ft_ToolTip_Text := ft_ToolTip_Text_Part1 . ft_ToolTip_Text_Part2 . ft_ToolTip_Text_Part3

--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -3101,7 +3101,7 @@
         Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesLinked Checked%StashTabYesLinked% x+5 yp+4, Enable
 
         Gui, Inventory: Font, Bold s8 cBlack, Arial
-        Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , Bricked maps
+        Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , 'Bricked' Maps
         Gui, Inventory: Font,
         Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
         Gui, Inventory: Add, UpDown, Range1-99 x+0 yp hp gSaveStashTabs vStashTabBrickedMaps , %StashTabBrickedMaps%

--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -2297,11 +2297,11 @@
           Else
             sendstash := StashTabBlight
         }
+        Else If ((This.Prop.IsBrickedMap) && StashTabYesBrickedMaps)
+            sendstash := StashTabBrickedMaps
         Else If (This.Prop.IsMap && StashTabYesMap)
         {
-          If ((This.Prop.IsBrickedMap) && StashTabYesBrickedMaps)
-            sendstash := StashTabBrickedMaps
-          Else If StashTabYesMap > 1
+          If StashTabYesMap > 1
             sendstash := -2
           Else
             sendstash := StashTabMap

--- a/data/Library.ahk
+++ b/data/Library.ahk
@@ -883,6 +883,17 @@
           This.Prop.TopTierResists := (This.Prop.TopTierLightningResist?1:0) + (This.Prop.TopTierFireResist?1:0) + (This.Prop.TopTierColdResist?1:0) + (This.Prop.TopTierChaosResist?1:0)
       }
       BrickedMap() {
+        If (This.HasBrickedAffix()) {
+          If (BrickedWhenCorrupted && This.Prop.Corrupted)
+            Return True
+          Else If (!BrickedWhenCorrupted)
+            Return True
+          Else
+            Return False
+        } Else
+          Return False
+      }
+      HasBrickedAffix() {
         If ((This.Affix["Monsters have #% chance to Avoid Elemental Ailments"] && AvoidAilments) 
         || (This.Affix["Monsters have a #% chance to avoid Poison, Blind, and Bleeding"] && AvoidPBB) 
         || (This.Affix["Monsters reflect #% of Elemental Damage"] && ElementalReflect) 
@@ -3172,7 +3183,7 @@
         Gui, Inventory: Add, UpDown, Range1-100 x+0 yp hp gSaveStashTabs vStashTabYesNinjaPrice_Price , %StashTabYesNinjaPrice_Price%
 
         Gui, Inventory: Font, Bold s9 cBlack, Arial
-        Gui, Inventory: Add, GroupBox,             w180 h110    section    xs   y+10,         Map/Contract Options
+        Gui, Inventory: Add, GroupBox,             w180 h140    section    xs   y+10,         Map/Contract Options
         Gui, Inventory: Font,
         Gui, Inventory: Add, DropDownList, w40 gUpdateExtra  vYesSkipMaps_eval xs+5 yp+18 , % ">=|<=" 
         GuiControl,Inventory: ChooseString, YesSkipMaps_eval, %YesSkipMaps_eval%
@@ -3186,6 +3197,8 @@
         Gui, Inventory: Add, Text, xs+5 y+8 , Skip Maps => Tier
         Gui, Inventory: Add, Edit, Number w40 x+5 yp-3 
         Gui, Inventory: Add, UpDown, center hp w40 range1-16 gUpdateExtra vYesSkipMaps_tier , %YesSkipMaps_tier%
+
+        Gui, Inventory: Add, Checkbox, gUpdateExtra  vBrickedWhenCorrupted Checked%BrickedWhenCorrupted% xs+5 y+8, Only consider a map to be`rbricked if it's corrupted
 
 
         ; Affinity


### PR DESCRIPTION
- Make sure bricked maps are still stashed in the right tab if there isn't a tab set for normal maps.
- Override 'ignored map inventory' columns so bricked maps in those columns will still be stashed.
- Change call to brickedmap function to a call to the property set by the function previously.
- Add option to only consider a map to be 'bricked' if it's corrupted