### PR TITLE
Alpha

### DIFF
--- a/lib/CLASS_ItemScan.ahk
+++ b/lib/CLASS_ItemScan.ahk
@@ -2725,6 +2725,8 @@
 		}
 		Else If (This.Prop.Flask&&(This.Prop.Quality>0)&&StashTabYesFlaskQuality&&!This.Prop.RarityUnique)
 			sendstash := StashTabFlaskQuality
+		Else If (This.Prop.Flask&&(This.Prop.Quality<1)&&StashTabYesFlaskAll&&!This.Prop.RarityUnique)
+			sendstash := StashTabFlaskAll																															
 		Else If (This.Prop.RarityGem)
 		{
 			If ((This.Prop.Quality>0)&&StashTabYesGemQuality)

--- a/lib/GLOBALS.ahk
+++ b/lib/GLOBALS.ahk
@@ -336,6 +336,8 @@
 		StashTabYesGemQuality = Enable to send Quality Gem items to the assigned tab on the left
 		StashTabFlaskQuality = Assign the Stash tab for Quality Flask items
 		StashTabYesFlaskQuality = Enable to send Quality Flask items to the assigned tab on the left
+		StashTabFlaskAll = Assign the Stash tab for Quality Flask items
+		StashTabYesFlaskAll = Enable to send unquality flasks to the assigned tab on the left
 		StashTabLinked = Assign the Stash tab for 6 or 5 Linked items
 		StashTabYesLinked = Enable to send 6 or 5 Linked items to the assigned tab on the left
 		StashTabBrickedMaps = Assign the Stash tab for maps that have unwanted mods on them
@@ -700,6 +702,7 @@
 	Global StashTabGemVaal := 1
 	Global StashTabGemQuality := 1
 	Global StashTabFlaskQuality := 1
+	Global StashTabFlaskAll := 1							 
 	Global StashTabLinked := 1
 	Global StashTabBrickedMaps := 1
 	Global StashTabInfluencedItem := 1
@@ -734,6 +737,7 @@
 	Global StashTabYesGemVaal := 1
 	Global StashTabYesGemQuality := 1
 	Global StashTabYesFlaskQuality := 1
+	Global StashTabYesFlaskAll := 1								
 	Global StashTabYesLinked := 1
 	Global StashTabYesBrickedMaps := 1
 	Global StashTabYesInfluencedItem := 1

--- a/lib/SaveLoad.ahk
+++ b/lib/SaveLoad.ahk
@@ -206,6 +206,7 @@
 	IniRead, StashTabGem, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGem, 1
 	IniRead, StashTabGemQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGemQuality, 1
 	IniRead, StashTabFlaskQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskQuality, 1
+	IniRead, StashTabFlaskAll, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskAll, 1																						   
 	IniRead, StashTabLinked, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabLinked, 1
 	IniRead, StashTabBrickedMaps, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBrickedMaps, 1
 	IniRead, StashTabUnique, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUnique, 1
@@ -237,6 +238,7 @@
 	IniRead, StashTabYesGemQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemQuality, 1
 	IniRead, StashTabYesGemSupport, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemSupport, 1
 	IniRead, StashTabYesFlaskQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskQuality, 1
+	IniRead, StashTabYesFlaskAll, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskAll, 1																								 
 	IniRead, StashTabYesLinked, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesLinked, 1
 	IniRead, StashTabYesUnique, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUnique, 1
 	IniRead, StashTabYesUniqueRing, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUniqueRing, 1
@@ -944,6 +946,7 @@ updateEverything:
 	IniWrite, %StashTabGem%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGem
 	IniWrite, %StashTabGemQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGemQuality
 	IniWrite, %StashTabFlaskQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskQuality
+	IniWrite, %StashTabFlaskAll%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskAll																						   
 	IniWrite, %StashTabLinked%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabLinked
 	IniWrite, %StashTabBrickedMaps%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBrickedMaps
 	IniWrite, %StashTabUnique%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUnique
@@ -972,6 +975,7 @@ updateEverything:
 	IniWrite, %StashTabYesGemQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemQuality
 	IniWrite, %StashTabYesGemSupport%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemSupport
 	IniWrite, %StashTabYesFlaskQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskQuality
+	IniWrite, %StashTabYesFlaskAll%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskAll																								 
 	IniWrite, %StashTabYesLinked%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesLinked
 	IniWrite, %StashTabYesUnique%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUnique
 	IniWrite, %StashTabYesUniqueRing%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUniqueRing

--- a/lib/gui/UtilityMenu.ahk
+++ b/lib/gui/UtilityMenu.ahk
@@ -72,6 +72,7 @@
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "Move xs+10   yp+20 Checked" WR.Utility[slot].Move , Enable
 
 		Gui, Utility%slot%: Add, GroupBox, center xs y+20 w110 h95, Trigger with Attack
+		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "MainAttackOnly xs+10 yp+20 Checked" WR.Utility[slot].MainAttackOnly, Main	Attack Only	
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "MainAttack xs+10 yp+20 Checked" WR.Utility[slot].MainAttack, Main
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "MainAttackRelease xs+10 y+5 Checked" WR.Utility[slot].MainAttackRelease, Main Release
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "SecondaryAttack xs+10   y+5 Checked" WR.Utility[slot].SecondaryAttack, Secondary
@@ -122,7 +123,7 @@
 	Return
 
 	UtilitySaveValues:
-		for k, kind in ["Enable", "OnCD", "CD", "GroupCD", "Key", "MainAttack", "SecondaryAttack", "MainAttackRelease", "SecondaryAttackRelease", "PopAll", "Icon", "IconShown", "IconSearch", "IconArea", "Move", "Group", "Condition", "Curse", "Shock", "Bleed", "Freeze", "Ignite", "Poison"]
+		for k, kind in ["Enable", "OnCD", "CD", "GroupCD", "Key", "MainAttackOnly", "MainAttack", "SecondaryAttack", "MainAttackRelease", "SecondaryAttackRelease", "PopAll", "Icon", "IconShown", "IconSearch", "IconArea", "Move", "Group", "Condition", "Curse", "Shock", "Bleed", "Freeze", "Ignite", "Poison"]
 			WR.Utility[which][kind] := Utility%which%%kind%
 		for k, kind in ["Life", "ES", "Mana"]
 			WR.Utility[which][kind] := Utility%which%%kind%_Slider.Slider_Value 

--- a/lib/gui/WR_Menu.ahk
+++ b/lib/gui/WR_Menu.ahk
@@ -233,6 +233,13 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
       Gui, Inventory: Add, UpDown, Range1-99 x+0 yp hp gSaveStashTabs vStashTabFlaskQuality , %StashTabFlaskQuality%
       Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesFlaskQuality Checked%StashTabYesFlaskQuality% x+5 yp+4, Enable
+	  
+	  Gui, Inventory: Font, Bold s8 cBlack, Arial
+      Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , Unquality Flask
+      Gui, Inventory: Font,
+      Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
+      Gui, Inventory: Add, UpDown, Range1-99 x+0 yp hp gSaveStashTabs vStashTabFlaskAll , %StashTabFlaskAll%
+      Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesFlaskAll Checked%StashTabYesFlaskAll% x+5 yp+4, Enable
 
       Gui, Inventory: Font, Bold s9 cBlack, Arial
       Gui, Inventory: Add, GroupBox,             w180 h60    section    x+15 ys,         Dump Tab

--- a/lib/routine/MainLogic.ahk
+++ b/lib/routine/MainLogic.ahk
@@ -187,6 +187,8 @@ TGameTick(GuiCheck:=True){
 				{
 					If (WR.Utility[A_Index].Enable && WR.cdExpires.Utility[A_Index] <= A_TickCount)
 					{
+						If (NOT WR.Utility[A_Index].MainAttackOnly || ( WR.Utility[A_Index].MainAttackOnly && MainAttackPressedActive ))
+						{																									 
 						If (( WR.Utility[A_Index].OnCD )
 						|| ( WR.Utility[A_Index].ES && WR.Utility[A_Index].ES > Player.Percent.ES )
 						|| ( WR.Utility[A_Index].Life && WR.Utility[A_Index].Life > Player.Percent.Life )
@@ -205,8 +207,8 @@ TGameTick(GuiCheck:=True){
 							
 							If ((WR.Utility[A_Index].IconShown && BuffIcon) || (!WR.Utility[A_Index].IconShown && !BuffIcon))
 								Trigger(WR.Utility[A_Index],True)
-							Else
 								WR.cdExpires.Utility[A_Index] := A_TickCount + (WR.Utility[A_Index].IconShow ? 150 : WR.Utility[A_Index].CD)
+						}
 						}
 					}
 				}


### PR DESCRIPTION
I added a "Main Attack Only" Checkmark in the utility menu, this is so triggers dont happen all the time, but only while main attacking.

MainAttackOnly is by default checked and sometimes needs to be unchecked and rechecked. I need to find how to properly save this (saveload?, ini edit?) Would appreciate the help.

This differs from main, because main casts all the time during main. You can now for instance trigger a Text Search only when main attacking. Use for buffs/totems/hexes/etc...

I added an "Unquality flask" option to Inventory-> Stash Tabs. This is for leveling so that you can deposit all your flasks and upgrade them end of act or whenever.

I'm really new at Github so let me know if you like my ideas and if I'm heading the right direction!

