### PR TITLE
Alpha

### DIFF
--- a/lib/CLASS_ItemScan.ahk
+++ b/lib/CLASS_ItemScan.ahk
@@ -30,7 +30,7 @@
 				Else
 					This.Data.Blocks.Properties .= SVal "`r`n"
 			}
-			Else 
+			Else
 			{
 				If (SVal ~= "\.$" || SVal ~= "\?$" || SVal ~= """$")
 					This.Data.Blocks.FlavorText := SVal
@@ -70,6 +70,7 @@
 			This.ApproximatePerfection()
 		This.MatchPseudoAffix()
 		This.MatchExtenalDB()
+		This.MatchCustomCrafting()
 		This.MatchCraftingBases()
 		This.MatchBase2Slot()
 		This.MatchChaosRegal()
@@ -253,7 +254,7 @@
 				}
 			}
 			;Start Parse
-			
+
 			; We match one of these against an item to identify its purpose
 			If (This.Prop.ItemClass = "Misc Map Items")
 			{
@@ -283,19 +284,19 @@
 				This.Prop.Incubator := True
 				This.Prop.SpecialType := "Incubator"
 			}
-			Else If (InStr(This.Prop.ItemBase, "Timeless Karui Splinter") 
-			|| InStr(This.Prop.ItemBase, "Timeless Eternal Empire Splinter") 
-			|| InStr(This.Prop.ItemBase, "Timeless Vaal Splinter") 
-			|| InStr(This.Prop.ItemBase, "Timeless Templar Splinter") 
+			Else If (InStr(This.Prop.ItemBase, "Timeless Karui Splinter")
+			|| InStr(This.Prop.ItemBase, "Timeless Eternal Empire Splinter")
+			|| InStr(This.Prop.ItemBase, "Timeless Vaal Splinter")
+			|| InStr(This.Prop.ItemBase, "Timeless Templar Splinter")
 			|| InStr(This.Prop.ItemBase, "Timeless Maraketh Splinter"))
 			{
 				This.Prop.TimelessSplinter := True
 				This.Prop.SpecialType := "Timeless Splinter"
 			}
-			Else If (InStr(This.Prop.ItemBase, "Timeless Karui Emblem") 
-			|| InStr(This.Prop.ItemBase, "Timeless Eternal Emblem") 
-			|| InStr(This.Prop.ItemBase, "Timeless Vaal Emblem") 
-			|| InStr(This.Prop.ItemBase, "Timeless Templar Emblem") 
+			Else If (InStr(This.Prop.ItemBase, "Timeless Karui Emblem")
+			|| InStr(This.Prop.ItemBase, "Timeless Eternal Emblem")
+			|| InStr(This.Prop.ItemBase, "Timeless Vaal Emblem")
+			|| InStr(This.Prop.ItemBase, "Timeless Templar Emblem")
 			|| InStr(This.Prop.ItemBase, "Timeless Maraketh Emblem"))
 			{
 				This.Prop.TimelessEmblem := True
@@ -327,8 +328,8 @@
 				This.Prop.MapPrep := True
 				This.Prop.SpecialType := "Sacrifice Fragment"
 			}
-			Else If (InStr(This.Prop.ItemBase, "Mortal Grief") 
-			|| InStr(This.Prop.ItemBase, "Mortal Hope") 
+			Else If (InStr(This.Prop.ItemBase, "Mortal Grief")
+			|| InStr(This.Prop.ItemBase, "Mortal Hope")
 			|| InStr(This.Prop.ItemBase, "Mortal Ignorance")
 			|| InStr(This.Prop.ItemBase, "Mortal Rage"))
 			{
@@ -340,7 +341,7 @@
 				This.Prop.GuardianFragment := True
 				This.Prop.SpecialType := "Guardian Fragment"
 			}
-			Else If (InStr(This.Prop.ItemBase, "Volkuur's Key") 
+			Else If (InStr(This.Prop.ItemBase, "Volkuur's Key")
 			|| InStr(This.Prop.ItemBase, "Eber's Key")
 			|| InStr(This.Prop.ItemBase, "Yriel's Key")
 			|| InStr(This.Prop.ItemBase, "Inya's Key"))
@@ -370,7 +371,7 @@
 				This.Prop.Essence := True
 				This.Prop.SpecialType := "Essence"
 			}
-			Else If (This.Prop.RarityCurrency 
+			Else If (This.Prop.RarityCurrency
 			&& (This.Prop.ItemBase ~= " Fossil$"))
 			{
 				This.Prop.Fossil := True
@@ -384,7 +385,7 @@
 					This.Prop.Item_Width := 1
 				Else
 					This.Prop.Item_Width := 2
-				
+
 				If (InStr(This.Prop.ItemName, "Primitive"))
 					This.Prop.Item_Height := 1
 				Else
@@ -555,7 +556,7 @@
 		If This.Prop.Influence {
 			If (This.Prop.Influence ~= "Fractured" || This.Prop.Influence ~= "Synthesised")
 				This.Prop.IsSynthesisItem := True
-			Else 
+			Else
 				This.Prop.IsInfluenceItem := True
 		}
 		; Get Prophecy/Beasts using Flavour Txt
@@ -666,13 +667,13 @@
 				This.Prop.IsWeapon := True
 				This.Prop.Weapon_APS := RxMatch1
 				If (RegExMatch(This.Data.Blocks.Properties, "`am)^Two Handed",RxMatch)){
-					This.Prop.IsTwoHanded := True  
+					This.Prop.IsTwoHanded := True
 				}
 				Else If (RegExMatch(This.Data.Blocks.Properties, "`am)^Staff",RxMatch)){
-					This.Prop.IsTwoHanded := True  
+					This.Prop.IsTwoHanded := True
 				}
 				Else If (RegExMatch(This.Data.Blocks.Properties, "`am)^Bow",RxMatch)){
-					This.Prop.IsTwoHanded := True  
+					This.Prop.IsTwoHanded := True
 				}
 				Else
 				{
@@ -698,7 +699,7 @@
 					For k, v in StrSplit(RxMatch,",")
 					{
 						values := This.MatchLine(v)
-						This.Prop.Weapon_Avg_Elemental_Dmg := Format("{1:0.3g}",This.Prop.Weapon_Avg_Elemental_Dmg + (values.1 + values.2) / 2 ) 
+						This.Prop.Weapon_Avg_Elemental_Dmg := Format("{1:0.3g}",This.Prop.Weapon_Avg_Elemental_Dmg + (values.1 + values.2) / 2 )
 						This.Prop.Weapon_Min_Elemental_Dmg += values.1
 						This.Prop.Weapon_Max_Elemental_Dmg += values.2
 					}
@@ -767,7 +768,7 @@
 			}
 		}
 		;End Prop Block Parser for Maps
-		
+
 		; Start Prop Block Parser for Heist
 		If indexOf(This.Prop.ItemClass, ["Contract","Blueprint"]) {
 			If (RegExMatch(This.Data.Blocks.Properties, "`am)^Heist Target: (.*)",RxMatch))
@@ -885,11 +886,11 @@
 			Return False
 	}
 	HasBrickedAffix() {
-		If ((This.Affix["Monsters have #% chance to Avoid Elemental Ailments"] && AvoidAilments) 
-		|| (This.Affix["Monsters have a #% chance to avoid Poison, Blind, and Bleeding"] && AvoidPBB) 
-		|| (This.Affix["Monsters reflect #% of Elemental Damage"] && ElementalReflect) 
-		|| (This.Affix["Monsters reflect #% of Physical Damage"] && PhysicalReflect) 
-		|| (This.Affix["Players cannot Regenerate Life, Mana or Energy Shield"] && NoRegen) 
+		If ((This.Affix["Monsters have #% chance to Avoid Elemental Ailments"] && AvoidAilments)
+		|| (This.Affix["Monsters have a #% chance to avoid Poison, Blind, and Bleeding"] && AvoidPBB)
+		|| (This.Affix["Monsters reflect #% of Elemental Damage"] && ElementalReflect)
+		|| (This.Affix["Monsters reflect #% of Physical Damage"] && PhysicalReflect)
+		|| (This.Affix["Players cannot Regenerate Life, Mana or Energy Shield"] && NoRegen)
 		|| (This.Affix["Cannot Leech Life from Monsters"] && NoLeech)
 		|| (This.Affix["-#% maximum Player Resistances"] && MinusMPR)
 		|| (This.Affix["Monsters fire # additional Projectiles"] && MFAProjectiles)
@@ -906,8 +907,8 @@
 		|| (This.Affix["Players have #% less Area of Effect"] && PHLessAreaOfEffect))
 		{
 			Return True
-		} 
-		Else 
+		}
+		Else
 		{
 			return False
 		}
@@ -1005,7 +1006,7 @@
 			Return True
 		Else If (This.Prop.ItemLevel < 60 && This.HasAffix("of Variegation"))
 			Return True
-		Else If ((This.Prop.ItemLevel < 85 || indexOf(This.Prop.ItemClass,["Rings"])) 
+		Else If ((This.Prop.ItemLevel < 85 || indexOf(This.Prop.ItemClass,["Rings"]))
 		&& This.HasAffix("of the Rainbow"))
 			Return True
 		Else If (This.Prop.ItemLevel <= 100 && This.HasAffix("of the Span"))
@@ -1019,10 +1020,10 @@
 			Return True
 		Else If (This.Prop.ItemLevel < 30 && This.HasAffix("of Nimbleness"))
 			Return True
-		Else If ((This.Prop.ItemLevel < 40 || indexOf(This.Prop.ItemClass,["Amulets"])) 
+		Else If ((This.Prop.ItemLevel < 40 || indexOf(This.Prop.ItemClass,["Amulets"]))
 		&& This.HasAffix("of Expertise"))
 			Return True
-		Else If ((This.Prop.ItemLevel < 55 || indexOf(This.Prop.ItemClass,["Gloves"])) 
+		Else If ((This.Prop.ItemLevel < 55 || indexOf(This.Prop.ItemClass,["Gloves"]))
 		&& This.HasAffix("of Legerdemain"))
 			Return True
 		Else If (This.Prop.ItemLevel < 72 && This.HasAffix("of Prestidigitation"))
@@ -1040,10 +1041,10 @@
 			Return True
 		Else If (This.Prop.ItemLevel < 22 && This.HasAffix("of Ease"))
 			Return True
-		Else If ((This.Prop.ItemLevel < 30 || indexOf(This.Prop.ItemClass,["Shields"])) 
+		Else If ((This.Prop.ItemLevel < 30 || indexOf(This.Prop.ItemClass,["Shields"]))
 		&& This.HasAffix("of Mastery"))
 			Return True
-		Else If ((This.Prop.ItemLevel < 37 || indexOf(This.Prop.ItemClass,["Gloves"])) 
+		Else If ((This.Prop.ItemLevel < 37 || indexOf(This.Prop.ItemClass,["Gloves"]))
 		&& This.HasAffix("of Renown"))
 			Return True
 		Else If (This.Prop.ItemLevel < 45 && This.HasAffix("of Acclaim"))
@@ -1083,37 +1084,37 @@
 	}
 	TopTierCritMulti(){
 		If (This.Prop.ItemLevel < 21
-		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 8 
+		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 8
 			|| This.Affix["#% to Critical Strike Multiplier with Bows"] >= 8 ))
 			Return True
 		Else If (This.Prop.ItemLevel < 31
-		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 13 
+		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 13
 			|| This.Affix["#% to Critical Strike Multiplier with Bows"] >= 13 ))
 			Return True
 		Else If (This.Prop.ItemLevel < 45
-		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 20 
+		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 20
 			|| This.Affix["#% to Critical Strike Multiplier with Bows"] >= 20 ))
 			Return True
 		Else If (This.Prop.ItemLevel < 59
-		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 25 
+		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 25
 			|| This.Affix["#% to Critical Strike Multiplier with Bows"] >= 25 ))
 			Return True
 		Else If (This.Prop.ItemLevel < 75
-		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 30 
+		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 30
 			|| This.Affix["#% to Critical Strike Multiplier with Bows"] >= 30 ))
 			Return True
 		Else If (This.Prop.ItemLevel < 75 && (This.Prop.ItemClass = "Rings" || This.Prop.ItemClass = "Helmets")
 		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 8 ))
 			Return True
 		Else If (This.Prop.ItemLevel < 75
-		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 30 
+		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 30
 			|| This.Affix["#% to Critical Strike Multiplier with Bows"] >= 30 ))
 			Return True
 		Else If (This.Prop.ItemLevel < 80 && (This.Prop.ItemClass = "Rings" || This.Prop.ItemClass = "Helmets")
 		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 13 ))
 			Return True
 		Else If (This.Prop.ItemLevel <= 100
-		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 35 
+		&& (This.Affix["#% to Global Critical Strike Multiplier"] >= 35
 			|| This.Affix["#% to Critical Strike Multiplier with Bows"] >= 35 ))
 			Return True
 		Else If (This.Prop.ItemLevel <= 100 && (This.Prop.ItemClass = "Rings" || This.Prop.ItemClass = "Helmets")
@@ -1124,30 +1125,30 @@
 	}
 	TopTierCritChance(){
 		If ((This.Prop.ItemLevel < 20 || This.Prop.ItemClass = "Rings")
-		&& (This.Affix["#% increased Critical Strike Chance"] >= 10 
-			|| This.Affix["#% increased Global Critical Strike Chance"] >= 10 
+		&& (This.Affix["#% increased Critical Strike Chance"] >= 10
+			|| This.Affix["#% increased Global Critical Strike Chance"] >= 10
 			|| This.Affix["#% increased Critical Strike Chance with Bows"] >= 10 ))
 			Return True
 		Else If ((This.Prop.ItemLevel < 30 || !(This.Prop.IsWeapon || This.Prop.ItemClass = "Amulets" || This.Prop.ItemClass = "Quivers"))
-		&& (This.Affix["#% increased Critical Strike Chance"] >= 15 
-			|| This.Affix["#% increased Global Critical Strike Chance"] >= 15 
+		&& (This.Affix["#% increased Critical Strike Chance"] >= 15
+			|| This.Affix["#% increased Global Critical Strike Chance"] >= 15
 			|| This.Affix["#% increased Critical Strike Chance with Bows"] >= 15 ))
 			Return True
-		Else If (This.Prop.ItemLevel < 44 
-		&& (This.Affix["#% increased Critical Strike Chance"] >= 20 
-			|| This.Affix["#% increased Global Critical Strike Chance"] >= 20 
+		Else If (This.Prop.ItemLevel < 44
+		&& (This.Affix["#% increased Critical Strike Chance"] >= 20
+			|| This.Affix["#% increased Global Critical Strike Chance"] >= 20
 			|| This.Affix["#% increased Critical Strike Chance with Bows"] >= 20 ))
 			Return True
-		Else If (This.Prop.ItemLevel < 58 
-		&& (This.Affix["#% increased Global Critical Strike Chance"] >= 25 
+		Else If (This.Prop.ItemLevel < 58
+		&& (This.Affix["#% increased Global Critical Strike Chance"] >= 25
 			|| This.Affix["#% increased Critical Strike Chance with Bows"] >= 25 ))
 			Return True
-		Else If (This.Prop.ItemLevel < 59 
+		Else If (This.Prop.ItemLevel < 59
 		&& (This.Affix["#% increased Critical Strike Chance"] >= 25 ))
 			Return True
-		Else If (This.Prop.ItemLevel <= 100 
-		&& (This.Affix["#% increased Critical Strike Chance"] >= 30 
-			|| This.Affix["#% increased Global Critical Strike Chance"] >= 30 
+		Else If (This.Prop.ItemLevel <= 100
+		&& (This.Affix["#% increased Critical Strike Chance"] >= 30
+			|| This.Affix["#% increased Global Critical Strike Chance"] >= 30
 			|| This.Affix["#% increased Critical Strike Chance with Bows"] >= 30 ))
 			Return True
 		Else
@@ -1277,8 +1278,8 @@
 		|| !( This.Prop.SlotType )
 		|| ( ChaosRecipeTypePure && This.Prop.ItemLevel > 74)
 		|| ( ChaosRecipeTypeRegal && This.Prop.ItemLevel < 75 )
-		|| ( ChaosRecipeSmallWeapons && (This.Prop.IsWeapon || This.Prop.ItemClass = "Shields") 
-			&& (( This.Prop.Item_Width > 1 && This.Prop.Item_Height > 2) || ( This.Prop.Item_Width = 1 && This.Prop.Item_Height > 3)) 
+		|| ( ChaosRecipeSmallWeapons && (This.Prop.IsWeapon || This.Prop.ItemClass = "Shields")
+			&& (( This.Prop.Item_Width > 1 && This.Prop.Item_Height > 2) || ( This.Prop.Item_Width = 1 && This.Prop.Item_Height > 3))
 			&& !(This.Prop.IsTwoHanded && This.Prop.Item_Width = 2 && This.Prop.Item_Height = 3) )
 			Return False
 		If (ChaosRecipeSkipJC && (This.Prop.Jeweler || This.Prop.Chromatic))
@@ -1341,13 +1342,13 @@
 			If (This.Prop.SlotType = v)
 			{
 				If This.Affix.Unidentified{
-					WeaponCount := retCount(RecipeArray.uRegal["Two Hand"]) + retCount(RecipeArray.uChaos["Two Hand"]) 
+					WeaponCount := retCount(RecipeArray.uRegal["Two Hand"]) + retCount(RecipeArray.uChaos["Two Hand"])
 					WeaponCount += (retCount(RecipeArray.uRegal["One Hand"]) + retCount(RecipeArray.uChaos["One Hand"])) / 2
 					WeaponCount += (retCount(RecipeArray.uRegal["Shield"]) + retCount(RecipeArray.uChaos["Shield"])) / 2
 					ChaosRecipeMaxHolding := ChaosRecipeMaxHoldingUNID
 				}Else{
-					WeaponCount := retCount(RecipeArray.Regal["Two Hand"]) + retCount(RecipeArray.Chaos["Two Hand"]) 
-					WeaponCount += (retCount(RecipeArray.Regal["One Hand"]) + retCount(RecipeArray.Chaos["One Hand"])) / 2 
+					WeaponCount := retCount(RecipeArray.Regal["Two Hand"]) + retCount(RecipeArray.Chaos["Two Hand"])
+					WeaponCount += (retCount(RecipeArray.Regal["One Hand"]) + retCount(RecipeArray.Chaos["One Hand"])) / 2
 					WeaponCount += (retCount(RecipeArray.Regal["Shield"]) + retCount(RecipeArray.Chaos["Shield"])) / 2
 					ChaosRecipeMaxHolding := ChaosRecipeMaxHoldingID
 				}
@@ -1567,7 +1568,7 @@
 		{
 			; Standardize implicit and crafted for Pseudo sums
 			; Implicits can be disable being merge into Pseudos checking YesCLFIgnoreImplicit
-			If (RegExMatch(k, "`am) \((.*)\)$", RxMatch) && YesCLFIgnoreImplicit)	
+			If (RegExMatch(k, "`am) \((.*)\)$", RxMatch) && YesCLFIgnoreImplicit)
 			{
 				If (RxMatch1 != "crafted")
 				{
@@ -1681,7 +1682,7 @@
 			Else If (trimKey = "#% increased Armour and Energy Shield")
 			{
 				This.AddPseudoAffix("(Pseudo) Total Increased Armour",k)
-				This.AddPseudoAffix("(Pseudo) Total Increased Energy Shield",k) 
+				This.AddPseudoAffix("(Pseudo) Total Increased Energy Shield",k)
 			}
 			Else If (trimKey = "#% increased Armour and Evasion")
 			{
@@ -1991,8 +1992,8 @@
 		{
 			For k, v in Ninja.BaseType
 			{
-				If (This.Prop.ItemBase = v["name"] 
-				&& This.Prop.Influence ~= v["variant"] 
+				If (This.Prop.ItemBase = v["name"]
+				&& This.Prop.Influence ~= v["variant"]
 				&& This.Prop.ItemLevel >= v["levelRequired"])
 				{
 					This.Prop.ChaosValue := v["chaosValue"]
@@ -2011,7 +2012,7 @@
 		{
 			If (This.Prop[MatchKey] = v[NinjaKey])
 			{
-				If ((ApiStr = "Map" || ApiStr = "UniqueMap") 
+				If ((ApiStr = "Map" || ApiStr = "UniqueMap")
 				&& This.Prop.Map_Tier < v["mapTier"])
 					Continue
 				If (v["links"] && ApiStr ~= "Unique"
@@ -2089,7 +2090,7 @@
 			Gui, ItemInfo: Show, AutoSize, % This.Prop.ItemName " has no Graph Data" (This.Prop.IsMap?" for this Tier":"")
 			Return
 		}
-			
+
 		If (This.Data.Ninja["paySparkLine"])
 		{
 			dataPayPoint := This.Data.Ninja["paySparkLine"]["data"]
@@ -2399,7 +2400,7 @@
 				GuiControl,ItemInfo: , PData8, % dataPoint[6]
 				GuiControl,ItemInfo: , PComment9, Day 1 Change
 				GuiControl,ItemInfo: , PData9, % dataPoint[7]
-				GuiControl,ItemInfo: , PComment10, 
+				GuiControl,ItemInfo: , PComment10,
 				GuiControl,ItemInfo: , PData10,
 			}
 			Else
@@ -2478,8 +2479,8 @@
 				GuiControl,ItemInfo: , GroupBox2, % (LTGraph = "Base"? ("Value of " This.Prop.ItemLevel " " This.Prop.Influence " " This.Prop.ItemBase ) : (LTGraph = "Helm" ? "Value of " This.Data.HelmNinja["name"] : "") )
 				GuiControl,ItemInfo: , SComment1, Chaos Value
 				GuiControl,ItemInfo: , SData1, % (LTGraph = "Base"? This.Data.BaseNinja["chaosValue"] : (LTGraph = "Helm" ? This.Data.HelmNinja["chaosValue"] : "") )
-				GuiControl,ItemInfo: , SComment2, 
-				GuiControl,ItemInfo: , SData2, 
+				GuiControl,ItemInfo: , SComment2,
+				GuiControl,ItemInfo: , SData2,
 				GuiControl,ItemInfo: , SComment3, Chaos Value `% Change
 				GuiControl,ItemInfo: , SData3, % (LTGraph = "Base"? This.Data.BaseNinja["sparkline"]["totalChange"] : (LTGraph = "Helm" ? This.Data.HelmNinja["sparkline"]["totalChange"] : "") )
 				GuiControl,ItemInfo: , SComment4, Day 6 Change
@@ -2625,7 +2626,10 @@
 																			, "Blessing of Uul-Netol":0
 																			, "Blessing of Tul":0
 																			, "Blessing of Esh":0 }
-		If (StashTabYesCurrency && This.Prop.RarityCurrency && (This.Prop.SpecialType="" || This.Prop.SpecialType = "Ritual Item"))
+    If ((This.Prop.CustomTab) && StashTabYesCustom){
+	 			sendstash := This.Prop.CustomTabNumber
+		}
+		Else If (StashTabYesCurrency && This.Prop.RarityCurrency && (This.Prop.SpecialType="" || This.Prop.SpecialType = "Ritual Item"))
 		{
 			If (StashTabYesCurrency > 1 && !UnsupportedAffinityCurrencies.HasKey(This.Prop.ItemName))
 				sendstash := -2
@@ -2673,10 +2677,10 @@
 		}
 		Else If (This.Prop.TimelessSplinter || This.Prop.TimelessEmblem || This.Prop.BreachSplinter || This.Prop.Offering || This.Prop.UberDuberOffering || This.Prop.Vessel || This.Prop.Scarab || This.Prop.SacrificeFragment || This.Prop.MortalFragment || This.Prop.GuardianFragment || This.Prop.ProphecyFragment )&&StashTabYesFragment
 		{
-			If StashTabYesFragment > 1 
+			If StashTabYesFragment > 1
 				sendstash := -2
 			Else
-				sendstash := StashTabFragment 
+				sendstash := StashTabFragment
 		}
 		Else If (This.Prop.RarityDivination) && StashTabYesDivination
 		{
@@ -2699,7 +2703,7 @@
 			Else
 				sendstash := StashTabDelve
 		}
-		Else If ((StashTabYesUnique||StashTabYesUniqueRing||StashTabYesUniqueDump) && This.Prop.RarityUnique && This.Prop.IsOrgan="" 
+		Else If ((StashTabYesUnique||StashTabYesUniqueRing||StashTabYesUniqueDump) && This.Prop.RarityUnique && This.Prop.IsOrgan=""
 		&&( !StashTabYesUniquePercentage || (StashTabYesUniquePercentage && This.Prop.PercentageAffix >= StashTabUniquePercentage) ) )
 		{
 			If (StashTabYesUnique = 2)
@@ -2711,7 +2715,7 @@
 			Else If (StashTabYesUniqueDump)
 			sendstash := StashTabUniqueDump
 		}
-		Else If ( ((StashTabYesUniqueRing&&StashTabYesUniqueRingAll&&This.Prop.Ring) || (StashTabYesUniqueDump&&StashTabYesUniqueDumpAll)) && This.Prop.RarityUnique && This.Prop.IsOrgan="" 
+		Else If ( ((StashTabYesUniqueRing&&StashTabYesUniqueRingAll&&This.Prop.Ring) || (StashTabYesUniqueDump&&StashTabYesUniqueDumpAll)) && This.Prop.RarityUnique && This.Prop.IsOrgan=""
 		&& (StashTabYesUniquePercentage && This.Prop.PercentageAffix < StashTabUniquePercentage)  )
 		{
 			If (StashTabYesUniqueRing&&StashTabYesUniqueRingAll&&This.Prop.Ring)
@@ -2726,7 +2730,7 @@
 		Else If (This.Prop.Flask&&(This.Prop.Quality>0)&&StashTabYesFlaskQuality&&!This.Prop.RarityUnique)
 			sendstash := StashTabFlaskQuality
 		Else If (This.Prop.Flask&&(This.Prop.Quality<1)&&StashTabYesFlaskAll&&!This.Prop.RarityUnique)
-			sendstash := StashTabFlaskAll																															
+			sendstash := StashTabFlaskAll
 		Else If (This.Prop.RarityGem)
 		{
 			If ((This.Prop.Quality>0)&&StashTabYesGemQuality)
@@ -2750,13 +2754,13 @@
 			sendstash := StashTabClusterJewel
 		Else If (This.Prop.HeistGear&&StashTabYesHeistGear)
 			sendstash := StashTabHeistGear
-		Else If (StashTabYesCrafting 
-			&& ((YesStashATLAS && This.Prop.CraftingBase = "Atlas Base" && ((This.Prop.ItemLevel >= YesStashATLASCraftingIlvlMin && YesStashATLASCraftingIlvl) || !YesStashATLASCraftingIlvl)) 
-				|| (YesStashSTR && This.Prop.CraftingBase = "STR Base" && ((This.Prop.ItemLevel >= YesStashSTRCraftingIlvlMin && YesStashSTRCraftingIlvl) || !YesStashSTRCraftingIlvl)) 
-				|| (YesStashDEX && This.Prop.CraftingBase = "DEX Base" && ((This.Prop.ItemLevel >= YesStashDEXCraftingIlvlMin && YesStashDEXCraftingIlvl) || !YesStashDEXCraftingIlvl)) 
-				|| (YesStashINT && This.Prop.CraftingBase = "INT Base" && ((This.Prop.ItemLevel >= YesStashINTCraftingIlvlMin && YesStashINTCraftingIlvl) || !YesStashINTCraftingIlvl)) 
-				|| (YesStashHYBRID && This.Prop.CraftingBase = "Hybrid Base" && ((This.Prop.ItemLevel >= YesStashHYBRIDCraftingIlvlMin && YesStashHYBRIDCraftingIlvl) || !YesStashHYBRIDCraftingIlvl)) 
-				|| (YesStashJ && This.Prop.CraftingBase = "Jewel Base" && ((This.Prop.ItemLevel >= YesStashJCraftingIlvlMin && YesStashJCraftingIlvl) || !YesStashJCraftingIlvl)) 
+		Else If (StashTabYesCrafting
+			&& ((YesStashATLAS && This.Prop.CraftingBase = "Atlas Base" && ((This.Prop.ItemLevel >= YesStashATLASCraftingIlvlMin && YesStashATLASCraftingIlvl) || !YesStashATLASCraftingIlvl))
+				|| (YesStashSTR && This.Prop.CraftingBase = "STR Base" && ((This.Prop.ItemLevel >= YesStashSTRCraftingIlvlMin && YesStashSTRCraftingIlvl) || !YesStashSTRCraftingIlvl))
+				|| (YesStashDEX && This.Prop.CraftingBase = "DEX Base" && ((This.Prop.ItemLevel >= YesStashDEXCraftingIlvlMin && YesStashDEXCraftingIlvl) || !YesStashDEXCraftingIlvl))
+				|| (YesStashINT && This.Prop.CraftingBase = "INT Base" && ((This.Prop.ItemLevel >= YesStashINTCraftingIlvlMin && YesStashINTCraftingIlvl) || !YesStashINTCraftingIlvl))
+				|| (YesStashHYBRID && This.Prop.CraftingBase = "Hybrid Base" && ((This.Prop.ItemLevel >= YesStashHYBRIDCraftingIlvlMin && YesStashHYBRIDCraftingIlvl) || !YesStashHYBRIDCraftingIlvl))
+				|| (YesStashJ && This.Prop.CraftingBase = "Jewel Base" && ((This.Prop.ItemLevel >= YesStashJCraftingIlvlMin && YesStashJCraftingIlvl) || !YesStashJCraftingIlvl))
 				|| (YesStashAJ && This.Prop.CraftingBase = "Abyss Jewel Base" && ((This.Prop.ItemLevel >= YesStashAJCraftingIlvlMin && YesStashAJCraftingIlvl) || !YesStashAJCraftingIlvl))
 				|| (YesStashJewellery && This.Prop.CraftingBase = "Jewellery Base" && ((This.Prop.ItemLevel >= YesStashJewelleryCraftingIlvlMin && YesStashJewelleryCraftingIlvl) || !YesStashJewelleryCraftingIlvl)) )
 			&& (!This.Prop.Corrupted))
@@ -2783,7 +2787,7 @@
 				}
 			}
 		}
-		Else If (((StashDumpInTrial || StashTabYesDump) && CurrentLocation ~= "Aspirant's Trial") 
+		Else If (((StashDumpInTrial || StashTabYesDump) && CurrentLocation ~= "Aspirant's Trial")
 			|| (StashTabYesDump && (!StashDumpSkipJC || (StashDumpSkipJC && !(This.Prop.Jeweler || This.Prop.Chromatic)))))
 			sendstash := StashTabDump, This.Prop.DumpTabItem := True
 		Else If (This.Prop.SpecialType && This.Prop.SpecialType != "Heist Goods")
@@ -2927,7 +2931,7 @@
 							mismatched := true
 					}
 					if !mismatched {    ; no mismatch means all sections found in the string
-						matchedOR := true 
+						matchedOR := true
 						Break
 					}
 				}	Else if InStr(val, v)	{          ; If there was no & symbol this is an OR section
@@ -2960,6 +2964,14 @@
 					Return False
 		}
 		Return True
+	}
+	MatchCustomCrafting(){
+		If (This.Prop.Rarity_Digit == 4)
+			Return False
+		If(HasVal(CustomString,This.Prop.ItemBase))
+		{
+			This.Prop.CustomStringTab := "Atlas Base"
+		}
 	}
 	MatchCraftingBases(){
 		If (This.Prop.Rarity_Digit == 4)
@@ -3004,8 +3016,8 @@
 				If unique.pricePerfect
 				{
 					perccalc := This.percval(This.Prop.PercentageAffix,[unique.mean,unique.pricePerfect]) * (This.Prop.PercentageAffix/90)
-					This.Prop.UniquePerfectValue := perccalc < unique.mean ? unique.mean 
-					: perccalc > unique.pricePerfect ? unique.pricePerfect 
+					This.Prop.UniquePerfectValue := perccalc < unique.mean ? unique.mean
+					: perccalc > unique.pricePerfect ? unique.pricePerfect
 					: perccalc
 					This.Prop.UniqueNormalMean := unique.mean?unique.mean:0
 					This.Prop.UniquePerfectMaxVal := unique.pricePerfect

--- a/lib/CLASS_ItemScan.ahk
+++ b/lib/CLASS_ItemScan.ahk
@@ -2966,11 +2966,13 @@
 		Return True
 	}
 	MatchCustomCrafting(){
-		If (This.Prop.Rarity_Digit == 4)
-			Return False
-		If(HasVal(CustomString,This.Prop.ItemBase))
+		For k, v in CustomStrings
 		{
-			This.Prop.CustomStringTab := "Atlas Base"
+		  ThisCustomString := CustomStrings[k]["str"]
+		  If InStr(ThisCustomString, ItemName)
+		  {
+		    CustomStringTab := CustomStrings[k]["tab"]
+		  }
 		}
 	}
 	MatchCraftingBases(){

--- a/lib/CLASS_ItemScan.ahk
+++ b/lib/CLASS_ItemScan.ahk
@@ -2626,8 +2626,8 @@
 																			, "Blessing of Uul-Netol":0
 																			, "Blessing of Tul":0
 																			, "Blessing of Esh":0 }
-    If ((This.Prop.CustomTab) && StashTabYesCustom){
-	 			sendstash := This.Prop.CustomTabNumber
+    If ((This.Prop.CustomString) && YesStashCustom){
+	 			sendstash := This.Prop.CustomStringTab
 		}
 		Else If (StashTabYesCurrency && This.Prop.RarityCurrency && (This.Prop.SpecialType="" || This.Prop.SpecialType = "Ritual Item"))
 		{
@@ -2966,12 +2966,13 @@
 		Return True
 	}
 	MatchCustomCrafting(){
-		For k, v in CustomStrings
+		For k, v in CustomStringBases
 		{
-		  ThisCustomString := CustomStrings[k]["str"]
-		  If InStr(ThisCustomString, ItemName)
+		  ThisCustomString := CustomStringBases[k]["str"]
+		  If InStr(This.Prop.ItemName, ThisCustomString)
 		  {
-		    CustomStringTab := CustomStrings[k]["tab"]
+				This.Prop.CustomString := True
+		    This.Prop.CustomStringTab := CustomStringBases[k]["tab"]
 		  }
 		}
 	}

--- a/lib/GLOBALS.ahk
+++ b/lib/GLOBALS.ahk
@@ -55,7 +55,7 @@
 		, "Vial"]
 
 		; List Crafting Atlas Bases + Special Drops
-		jsonCustomStrings =
+		jsonCustomStringBases =
 		(
 			{
 			  "1": {
@@ -72,9 +72,9 @@
 			  }
 			}
 )
-		Global DefaultCustomStrings  := jsonCustomStrings
+		Global DefaultCustomStringBases  := jsonCustomStringBases
 
-		Global CustomStrings := []
+		Global CustomStringBases := []
 
 	; List Crafting Atlas Bases + Special Drops
 	Global DefaultcraftingBasesT1  := ["Apothecary's Gloves"
@@ -320,7 +320,6 @@
 		ChaosRecipeStashTab = Assign the Stash Tab that All Parts will be sorted into.
 		ChaosRecipeLimitUnId = Items will remain unidentified until this Item Level
 		AreaScale = Increases the Pixel box around the Mouse`rA setting of 0 will search under cursor`rCan behave strangely at very high range
-		StashTabYesCustom = Assign a custom tab for strings.
 		StashTabCurrency = Assign the Stash tab for Currency items
 		StashTabYesCurrency = Enable to send Currency items to the assigned tab on the left
 		StashTabMap = Assign the Stash tab for Map items
@@ -744,7 +743,6 @@
 ; Checkbox to activate each tab
 
 			;Affinities
-	Global StashTabYesCustom := 0
 	Global StashTabYesCurrency := 0
 	Global StashTabYesMap := 0
 	Global StashTabYesDivination := 0
@@ -816,7 +814,7 @@
 	Global YesStashJewelleryCraftingIlvlMin := 76
 
 ; Custom Searches
-	Global YesCustomSearch = 1
+	Global YesStashCustom = 1
 
 ; Skip Maps after column #
 	Global YesSkipMaps := 0

--- a/lib/GLOBALS.ahk
+++ b/lib/GLOBALS.ahk
@@ -53,7 +53,28 @@
 		, "UniqueAccessory"
 		, "Beast"
 		, "Vial"]
-	
+
+		; List Crafting Atlas Bases + Special Drops
+		jsonCustomStrings =
+		(
+			{
+			  "1": {
+			    "str": "Stone Hammer",
+			    "tab": "2"
+			  },
+			  "2": {
+			    "str": "Rock Breaker",
+			    "tab": "3"
+			  },
+			  "3": {
+			    "str": "Gavel",
+			    "tab": "4"
+			  }
+			}
+)
+		Global DefaultCustomStrings  := jsonCustomStrings
+
+
 	; List Crafting Atlas Bases + Special Drops
 	Global DefaultcraftingBasesT1  := ["Apothecary's Gloves"
 		,"Blessed Boots"
@@ -296,6 +317,7 @@
 		ChaosRecipeStashTab = Assign the Stash Tab that All Parts will be sorted into.
 		ChaosRecipeLimitUnId = Items will remain unidentified until this Item Level
 		AreaScale = Increases the Pixel box around the Mouse`rA setting of 0 will search under cursor`rCan behave strangely at very high range
+		StashTabYesCustom = Assign a custom tab for strings.
 		StashTabCurrency = Assign the Stash tab for Currency items
 		StashTabYesCurrency = Enable to send Currency items to the assigned tab on the left
 		StashTabMap = Assign the Stash tab for Map items
@@ -313,7 +335,7 @@
 		StashTabVeiled = Assign the Stash tab for Veiled items
 		StashTabYesVeiled = Enable to send Veiled items to the assigned tab on the left
 		StashTabNinjaPrice = Assign the Stash tab for Ninja Priced items
-		StashTabYesNinjaPrice = Enable to send Ninja Priced items to the assigned tab on the left`rChaos Value must be at or above threshold 
+		StashTabYesNinjaPrice = Enable to send Ninja Priced items to the assigned tab on the left`rChaos Value must be at or above threshold
 		StashTabYesNinjaPrice_Price = Assign the minimum value in chaos to send to Ninja Priced Tab
 		StashTabPredictive = Assign the Stash tab for Rare items priced with Machine Learning
 		StashTabYesPredictive = Enable to send Priced Rare items to the assigned tab on the left`rPredicted price value must be at or above threshold
@@ -325,7 +347,7 @@
 		StashDumpInTrial = Enables dump tab for all unsorted items when in Aspirant's Trial
 		StashDumpSkipJC = Do not stash Jewler or Chromatic items when dumping
 		StashTabGemSupport = Assign the Stash tab for Support Gem items
-		StashTabYesGemSupport = Enable to send Support Gem items to the assigned tab on the left  
+		StashTabYesGemSupport = Enable to send Support Gem items to the assigned tab on the left
 		StashTabMetamorph = Assign the Stash tab for Metamorph items
 		StashTabYesMetamorph = Enable to send Metamorph items to the assigned tab on the left
 		StashTabGem = Assign the Stash tab for Normal Gem items
@@ -702,7 +724,7 @@
 	Global StashTabGemVaal := 1
 	Global StashTabGemQuality := 1
 	Global StashTabFlaskQuality := 1
-	Global StashTabFlaskAll := 1							 
+	Global StashTabFlaskAll := 1
 	Global StashTabLinked := 1
 	Global StashTabBrickedMaps := 1
 	Global StashTabInfluencedItem := 1
@@ -717,8 +739,9 @@
 	Global StashTabPredictive := 1
 	Global StashTabNinjaPrice := 1
 ; Checkbox to activate each tab
-	
+
 			;Affinities
+	Global StashTabYesCustom := 0
 	Global StashTabYesCurrency := 0
 	Global StashTabYesMap := 0
 	Global StashTabYesDivination := 0
@@ -732,12 +755,12 @@
 	;Unique Special
 	Global StashTabYesUniqueRing := 1
 	Global StashTabYesUniqueDump := 1
-	
+
 	Global StashTabYesGem := 1
 	Global StashTabYesGemVaal := 1
 	Global StashTabYesGemQuality := 1
 	Global StashTabYesFlaskQuality := 1
-	Global StashTabYesFlaskAll := 1								
+	Global StashTabYesFlaskAll := 1
 	Global StashTabYesLinked := 1
 	Global StashTabYesBrickedMaps := 1
 	Global StashTabYesInfluencedItem := 1
@@ -789,6 +812,9 @@
 	Global YesStashJewelleryCraftingIlvl := 0
 	Global YesStashJewelleryCraftingIlvlMin := 76
 
+; Custom Searches
+	Global YesCustomSearch = 1
+
 ; Skip Maps after column #
 	Global YesSkipMaps := 0
 	Global YesSkipMaps_Prep := 1
@@ -815,7 +841,7 @@
 	global YesTriggerUtilityJoystickKey := 1
 	global YesTriggerJoystickRightKey := 1
 ; ~ Hotkeys
-; Legend:    ! = Alt    ^ = Ctrl    + = Shift 
+; Legend:    ! = Alt    ^ = Ctrl    + = Shift
 	global hotkeyOptions:="!F10"
 	global hotkeyAutoFlask:="!F11"
 	global hotkeyAutoQuit:="!F12"
@@ -887,10 +913,10 @@
 	, CraftingMapMethod1,CraftingMapMethod2,CraftingMapMethod3
 	, ElementalReflect,PhysicalReflect,NoLeech,NoRegen,AvoidAilments,AvoidPBB,MinusMPR,LRRLES,MFAProjectiles,MDExtraPhysicalDamage,MICSC,MSCAT
 	, MMapItemQuantity,MMapItemRarity,MMapMonsterPackSize,EnableMQQForMagicMap,PCDodgeUnlucky,MHAccuracyRating, PHReducedChanceToBlock, PHLessArmour, PHLessAreaOfEffect
-	
+
 ; ItemInfo GUI
-	Global PercentText1G1, PercentText1G2, PercentText1G3, PercentText1G4, PercentText1G5, PercentText1G6, PercentText1G7, PercentText1G8, PercentText1G9, PercentText1G10, PercentText1G11, PercentText1G12, PercentText1G13, PercentText1G14, PercentText1G15, PercentText1G16, PercentText1G17, PercentText1G18, PercentText1G19, PercentText1G20, PercentText1G21, 
-	Global PercentText2G1, PercentText2G2, PercentText2G3, PercentText2G4, PercentText2G5, PercentText2G6, PercentText2G7, PercentText2G8, PercentText2G9, PercentText2G10, PercentText2G11, PercentText2G12, PercentText2G13, PercentText2G14, PercentText2G15, PercentText2G16, PercentText2G17, PercentText2G18, PercentText2G19, PercentText2G20, PercentText2G21, 
+	Global PercentText1G1, PercentText1G2, PercentText1G3, PercentText1G4, PercentText1G5, PercentText1G6, PercentText1G7, PercentText1G8, PercentText1G9, PercentText1G10, PercentText1G11, PercentText1G12, PercentText1G13, PercentText1G14, PercentText1G15, PercentText1G16, PercentText1G17, PercentText1G18, PercentText1G19, PercentText1G20, PercentText1G21,
+	Global PercentText2G1, PercentText2G2, PercentText2G3, PercentText2G4, PercentText2G5, PercentText2G6, PercentText2G7, PercentText2G8, PercentText2G9, PercentText2G10, PercentText2G11, PercentText2G12, PercentText2G13, PercentText2G14, PercentText2G15, PercentText2G16, PercentText2G17, PercentText2G18, PercentText2G19, PercentText2G20, PercentText2G21,
 	Global PComment1 := "LongDataTextNameSpace"
 	Global PData1 := "000.000"
 	Global PComment2 := "LongDataTextNameSpace"
@@ -943,4 +969,3 @@
 	Global ForceMatchGem20 := False
 ; Ingame Overlay Transparency
 	Global YesInGameOverlay := 0
-

--- a/lib/GLOBALS.ahk
+++ b/lib/GLOBALS.ahk
@@ -74,6 +74,7 @@
 )
 		Global DefaultCustomStrings  := jsonCustomStrings
 
+		Global CustomStrings := []
 
 	; List Crafting Atlas Bases + Special Drops
 	Global DefaultcraftingBasesT1  := ["Apothecary's Gloves"

--- a/lib/Library.ahk
+++ b/lib/Library.ahk
@@ -50,6 +50,7 @@
 #Include, %A_ScriptDir%\lib\gui\UtilityMenu.ahk
 #Include, %A_ScriptDir%\lib\gui\WR_Menu.ahk
 #Include, %A_ScriptDir%\lib\gui\CustomCraftingBase.ahk
+#Include, %A_ScriptDir%\lib\gui\CustomStringsSearch.ahk
 
 #Include, %A_ScriptDir%\lib\routine\AutoLevelGems.ahk
 #Include, %A_ScriptDir%\lib\routine\ChaosRecipe.ahk

--- a/lib/SaveLoad.ahk
+++ b/lib/SaveLoad.ahk
@@ -84,6 +84,7 @@
 	IniRead, YesStashJewellery, %A_ScriptDir%\save\Settings.ini, General, YesStashJewellery, 1
 	IniRead, YesStashJewelleryCraftingIlvl, %A_ScriptDir%\save\Settings.ini, General, YesStashJewelleryCraftingIlvl, 0
 	IniRead, YesStashJewelleryCraftingIlvlMin, %A_ScriptDir%\save\Settings.ini, General, YesStashJewelleryCraftingIlvlMin, 76
+	IniRead, YesStashCustom, %A_ScriptDir%\save\Settings.ini, General, YesStashCustom, 1
 	IniRead, YesGuiLastPosition, %A_ScriptDir%\save\Settings.ini, General, YesGuiLastPosition, 0
 	IniRead, YesSkipMaps, %A_ScriptDir%\save\Settings.ini, General, YesSkipMaps, 11
 	IniRead, YesSkipMaps_Prep, %A_ScriptDir%\save\Settings.ini, General, YesSkipMaps_Prep, 1
@@ -127,9 +128,6 @@
 	IniRead, BasicCraftSocketAuto, %A_ScriptDir%\save\Settings.ini, Basic Craft, BasicCraftSocketAuto, 1
 
 	;Crafting Bases
-	IniRead, YesStashCustom, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashCustom, 1
-
-	;Crafting Bases
 	IniRead, YesStashATLAS, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLAS, 1
 	IniRead, YesStashATLASCraftingIlvl, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLASCraftingIlvl, 0
 	IniRead, YesStashATLASCraftingIlvlMin, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLASCraftingIlvlMin, 76
@@ -161,6 +159,9 @@
 	IniRead, YesStashJewellery, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJewellery, 1
 	IniRead, YesStashJewelleryCraftingIlvl, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJewelleryCraftingIlvl, 0
 	IniRead, YesStashJewelleryCraftingIlvlMin, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJewelleryCraftingIlvlMin, 76
+
+	;Crafting Bases
+	IniRead, YesStashCustom, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashCustom, 1
 
 	;Crafting Map Settings
 	IniRead, StartMapTier1, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, StartMapTier1, 1
@@ -301,10 +302,10 @@
 
 	;Crafting Bases Settings
 	;Loading Default List
-	sDefaultCustomStrings := JSON.Dump(DefaultCustomStrings)
-	IniRead, CustomStrings, %A_ScriptDir%\save\Settings.ini, Custom String Settings, CustomString, %DefaultCustomStrings%
+	sDefaultCustomStringBases := JSON.Dump(DefaultCustomStringBases)
+	IniRead, CustomStringBases, %A_ScriptDir%\save\Settings.ini, Custom String Settings, CustomStringBases, %DefaultCustomStringBases%
 	;Converting string to array
-	CustomStrings := JSON.Load(CustomStrings)
+	CustomStringBases := JSON.Load(CustomStringBases)
 
 	;Crafting Bases Settings
 	;Loading Default List
@@ -881,8 +882,6 @@ updateEverything:
 	IniWrite, %GrabCurrencyX%, %A_ScriptDir%\save\Settings.ini, Grab Currency, GrabCurrencyX
 	IniWrite, %GrabCurrencyY%, %A_ScriptDir%\save\Settings.ini, Grab Currency, GrabCurrencyY
 
-	;Crafting Bases
-	IniWrite, %YesStashCustom%, %A_ScriptDir%\save\Settings.ini, Custom String Settings, YesStashCustom
 
 	;Crafting Bases
 	IniWrite, %YesStashATLAS%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLAS
@@ -917,6 +916,9 @@ updateEverything:
 	IniWrite, %YesStashJewelleryCraftingIlvl%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJewelleryCraftingIlvl
 	IniWrite, %YesStashJewelleryCraftingIlvlMin%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJewelleryCraftingIlvlMin
 
+	;Crafting Bases
+	IniWrite, %YesStashCustom%, %A_ScriptDir%\save\Settings.ini, Custom String Settings, YesStashCustom
+	
 	;Crafting Map Settings
 	IniWrite, %StartMapTier1%, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, StartMapTier1
 	IniWrite, %StartMapTier2%, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, StartMapTier2
@@ -1112,8 +1114,8 @@ updateEverything:
 	IniWrite, %ForceMatchGem20%, %A_ScriptDir%\save\Settings.ini, Database, ForceMatchGem20
 
 	;Crafting Bases Settings
-	sCustomStrings := JSON.Dump(CustomStrings)
-	IniWrite, %sCustomStrings%, %A_ScriptDir%\save\Settings.ini, Custom String Settings, CustomStrings
+	sCustomStringBases := JSON.Dump(CustomStringBases)
+	IniWrite, %sCustomStringBases%, %A_ScriptDir%\save\Settings.ini, Custom String Settings, CustomStringBases
 
 	;Crafting Bases Settings
 	scraftingBasesT1 := ArrayToString(craftingBasesT1)

--- a/lib/SaveLoad.ahk
+++ b/lib/SaveLoad.ahk
@@ -46,7 +46,7 @@
 	IniRead, YesDiv, %A_ScriptDir%\save\Settings.ini, General, YesDiv, 1
 	IniRead, YesMapUnid, %A_ScriptDir%\save\Settings.ini, General, YesMapUnid, 0
 	IniRead, YesInfluencedUnid, %A_ScriptDir%\save\Settings.ini, General, YesInfluencedUnid, 0
-	IniRead, YesCLFIgnoreImplicit, %A_ScriptDir%\save\Settings.ini, General, YesCLFIgnoreImplicit, 0 
+	IniRead, YesCLFIgnoreImplicit, %A_ScriptDir%\save\Settings.ini, General, YesCLFIgnoreImplicit, 0
 	IniRead, YesSortFirst, %A_ScriptDir%\save\Settings.ini, General, YesSortFirst, 1
 	IniRead, Latency, %A_ScriptDir%\save\Settings.ini, General, Latency, 1
 	IniRead, ClickLatency, %A_ScriptDir%\save\Settings.ini, General, ClickLatency, 0
@@ -59,6 +59,7 @@
 	IniRead, CharName, %A_ScriptDir%\save\Settings.ini, General, CharName, ReplaceWithCharName
 	IniRead, EnableChatHotkeys, %A_ScriptDir%\save\Settings.ini, General, EnableChatHotkeys, 1
 	IniRead, YesStashKeys, %A_ScriptDir%\save\Settings.ini, General, YesStashKeys, 1
+	IniRead, YesStashCustom, %A_ScriptDir%\save\Settings.ini, General, YesStashCustom, 1
 	IniRead, YesStashATLAS, %A_ScriptDir%\save\Settings.ini, General, YesStashATLAS, 1
 	IniRead, YesStashATLASCraftingIlvl, %A_ScriptDir%\save\Settings.ini, General, YesStashATLASCraftingIlvl, 0
 	IniRead, YesStashATLASCraftingIlvlMin, %A_ScriptDir%\save\Settings.ini, General, YesStashATLASCraftingIlvlMin, 76
@@ -126,6 +127,9 @@
 	IniRead, BasicCraftSocketAuto, %A_ScriptDir%\save\Settings.ini, Basic Craft, BasicCraftSocketAuto, 1
 
 	;Crafting Bases
+	IniRead, YesStashCustom, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashCustom, 1
+
+	;Crafting Bases
 	IniRead, YesStashATLAS, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLAS, 1
 	IniRead, YesStashATLASCraftingIlvl, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLASCraftingIlvl, 0
 	IniRead, YesStashATLASCraftingIlvlMin, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLASCraftingIlvlMin, 76
@@ -176,17 +180,17 @@
 	IniRead, MinusMPR, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MinusMPR, 0
 	IniRead, AvoidAilments, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, AvoidAilments, 0
 	IniRead, AvoidPBB, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, AvoidPBB, 0
-	IniRead, LRRLES, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, LRRLES, 0    
+	IniRead, LRRLES, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, LRRLES, 0
 	IniRead, MFAProjectiles, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MFAProjectiles, 0
 	IniRead, MDExtraPhysicalDamage, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MDExtraPhysicalDamage, 0
 	IniRead, MICSC, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MICSC, 0
 	IniRead, MSCAT, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MSCAT, 0
-	IniRead, PCDodgeUnlucky, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, PCDodgeUnlucky, 0   
+	IniRead, PCDodgeUnlucky, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, PCDodgeUnlucky, 0
 	IniRead, MHAccuracyRating, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MHAccuracyRating, 0
 	IniRead, PHReducedChanceToBlock, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, PHReducedChanceToBlock, 0
 	IniRead, PHLessArmour, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, PHLessArmour, 0
 	IniRead, PHLessAreaOfEffect, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, PHLessAreaOfEffect, 0
-	
+
 	IniRead, MMapItemQuantity, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MMapItemQuantity, 1
 	IniRead, MMapItemRarity, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MMapItemRarity, 1
 	IniRead, MMapMonsterPackSize, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MMapMonsterPackSize, 1
@@ -198,7 +202,7 @@
 	IniRead, YesEnableNextAutomation, %A_ScriptDir%\save\Settings.ini, Automation Settings, YesEnableNextAutomation, 0
 	IniRead, YesEnableAutoSellConfirmation, %A_ScriptDir%\save\Settings.ini, Automation Settings, YesEnableAutoSellConfirmation, 0
 	IniRead, YesEnableAutoSellConfirmationSafe, %A_ScriptDir%\save\Settings.ini, Automation Settings, YesEnableAutoSellConfirmationSafe, 0
-	
+
 	;Stash Tab Management
 	IniRead, StashTabCurrency, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabCurrency, 1
 	IniRead, StashTabMap, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabMap, 1
@@ -206,13 +210,13 @@
 	IniRead, StashTabGem, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGem, 1
 	IniRead, StashTabGemQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGemQuality, 1
 	IniRead, StashTabFlaskQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskQuality, 1
-	IniRead, StashTabFlaskAll, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskAll, 1																						   
+	IniRead, StashTabFlaskAll, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskAll, 1
 	IniRead, StashTabLinked, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabLinked, 1
 	IniRead, StashTabBrickedMaps, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBrickedMaps, 1
 	IniRead, StashTabUnique, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUnique, 1
 	IniRead, StashTabUniqueRing, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUniqueRing, 1
 	IniRead, StashTabUniqueDump, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUniqueDump, 1
-	IniRead, StashTabInfluencedItem, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabInfluencedItem, 1 
+	IniRead, StashTabInfluencedItem, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabInfluencedItem, 1
 	IniRead, StashTabFragment, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFragment, 1
 	IniRead, StashTabEssence, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabEssence, 1
 	IniRead, StashTabBlight, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBlight, 1
@@ -238,7 +242,7 @@
 	IniRead, StashTabYesGemQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemQuality, 1
 	IniRead, StashTabYesGemSupport, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemSupport, 1
 	IniRead, StashTabYesFlaskQuality, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskQuality, 1
-	IniRead, StashTabYesFlaskAll, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskAll, 1																								 
+	IniRead, StashTabYesFlaskAll, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskAll, 1
 	IniRead, StashTabYesLinked, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesLinked, 1
 	IniRead, StashTabYesUnique, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUnique, 1
 	IniRead, StashTabYesUniqueRing, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUniqueRing, 1
@@ -267,7 +271,7 @@
 	IniRead, StashTabNinjaPrice, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabNinjaPrice, 1
 	IniRead, StashTabYesNinjaPrice, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesNinjaPrice, 0
 	IniRead, StashTabYesNinjaPrice_Price, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesNinjaPrice_Price, 5
-	
+
 	; Chaos Recipe Settings
 	IniRead, ChaosRecipeEnableFunction, %A_ScriptDir%\save\Settings.ini, Chaos Recipe, ChaosRecipeEnableFunction, 0
 	IniRead, ChaosRecipeUnloadAll, %A_ScriptDir%\save\Settings.ini, Chaos Recipe, ChaosRecipeUnloadAll, 0
@@ -295,6 +299,12 @@
 	IniRead, ChaosRecipeStashTabAmulet, %A_ScriptDir%\save\Settings.ini, Chaos Recipe, ChaosRecipeStashTabAmulet, 1
 	IniRead, ChaosRecipeStashTabRing, %A_ScriptDir%\save\Settings.ini, Chaos Recipe, ChaosRecipeStashTabRing, 1
 
+	;Crafting Bases Settings
+	;Loading Default List
+	sDefaultCustomStrings := JSON.Dump(DefaultCustomStrings)
+	IniRead, CustomStrings, %A_ScriptDir%\save\Settings.ini, Custom String Search, CustomString, %DefaultCustomStrings%
+	;Converting string to array
+	CustomStrings := JSON.Load(CustomStrings)
 
 	;Crafting Bases Settings
 	;Loading Default List
@@ -323,13 +333,13 @@
 	craftingBasesT6 := StringToArray(craftingBasesT6)
 	craftingBasesT7 := StringToArray(craftingBasesT7)
 	craftingBasesT8 := StringToArray(craftingBasesT8)
-	
+
 	;Settings for the Client Log file location
 	IniRead, ClientLog, %A_ScriptDir%\save\Settings.ini, Log, ClientLog, %ClientLog%
-	
+
 	;Settings for the Overhead Health Bar
 	IniRead, YesOHB, %A_ScriptDir%\save\Settings.ini, OHB, YesOHB, 1
-	
+
 	;OHB Colors
 	IniRead, OHBLHealthHex, %A_ScriptDir%\save\Settings.ini, OHB, OHBLHealthHex, 0x19A631
 
@@ -396,7 +406,7 @@
 	IniRead, varOnMetamorph, %A_ScriptDir%\save\Settings.ini, Failsafe Colors, OnMetamorph, 0xE06718
 	IniRead, varOnLocker, %A_ScriptDir%\save\Settings.ini, Failsafe Colors, OnLocker, 0x1F2732
 	IniRead, varOnDetonate, %A_ScriptDir%\save\Settings.ini, Failsafe Colors, OnDetonate, 0x5D4661
-				
+
 	;Grab Currency From Inventory
 	IniRead, GrabCurrencyX, %A_ScriptDir%\save\Settings.ini, Grab Currency, GrabCurrencyX, 1877
 	IniRead, GrabCurrencyY, %A_ScriptDir%\save\Settings.ini, Grab Currency, GrabCurrencyY, 772
@@ -420,7 +430,7 @@
 	If hotkeyCraftBasic
 		hotkey,% hotkeyCraftBasic, CraftBasicPopUp, Off
 
-	
+
 	If hotkeyCtrlClicker
 		hotkey % hotkeyCtrlClicker,% CtrlSpam, Off
 	If hotkeyCtrlShiftClicker
@@ -433,7 +443,7 @@
 	hotkey, IfWinActive, ahk_group POEGameGroup
 
 	If hotkeyGrabCurrency
-		hotkey,% hotkeyGrabCurrency, GrabCurrencyCommand, Off  
+		hotkey,% hotkeyGrabCurrency, GrabCurrencyCommand, Off
 	If hotkeyGetCoords
 		hotkey,% hotkeyGetMouseCoords, CoordCommand, Off
 	If hotkeyPopFlasks
@@ -468,7 +478,7 @@
 	If hotkeyOptions
 		hotkey,% hotkeyOptions, optionsCommand, Off
 	hotkey, IfWinActive, ahk_group POEGameGroup
-		
+
 	;~ hotkeys iniread
 	IniRead, hotkeyOptions, %A_ScriptDir%\save\Settings.ini, hotkeys, Options, !F10
 	IniRead, hotkeyAutoQuit, %A_ScriptDir%\save\Settings.ini, hotkeys, AutoQuit, !F12
@@ -497,7 +507,7 @@
 	IniRead, hotkeyTriggerMovement, %A_ScriptDir%\save\Settings.ini, hotkeys, hotkeyTriggerMovement, LButton
 	IniRead, hotkeyCtrlClicker, %A_ScriptDir%\save\Settings.ini, hotkeys, CtrlClicker, % A_Space
 	IniRead, hotkeyCtrlShiftClicker, %A_ScriptDir%\save\Settings.ini, hotkeys, CtrlShiftClicker, % A_Space
-	
+
 	hotkey, IfWinActive, ahk_group POEGameGroup
 	If hotkeyAutoQuit
 		hotkey,% hotkeyAutoQuit, toggleAutoQuit, On
@@ -556,7 +566,7 @@
 		hotkey, $~%hotkeySecondaryAttack%, SecondaryAttackCommand, On
 		hotkey, $~%hotkeySecondaryAttack% Up, SecondaryAttackCommandRelease, On
 	}
-	
+
 	#MaxThreadsPerHotkey, 1
 	If hotkeyPauseMines
 		hotkey, $~%hotkeyPauseMines%, PauseMinesCommand, On
@@ -568,7 +578,7 @@
 		hotkey,!F10, optionsCommand, On
 		msgbox You dont have set the GUI hotkey!`nPlease hit Alt+F10 to open up the GUI and set your hotkey.
 		}
-	
+
 	IniRead, 1Prefix1, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 1Prefix1, a
 	IniRead, 1Prefix2, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 1Prefix2, %A_Space%
 	IniRead, 1Suffix1, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 1Suffix1, 1
@@ -602,7 +612,7 @@
 	IniRead, 2Suffix7, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix7, 7
 	IniRead, 2Suffix8, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix8, 8
 	IniRead, 2Suffix9, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix9, 9
-	
+
 	IniRead, 2Suffix1Text, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix1Text, Sure, will invite in a sec.
 	IniRead, 2Suffix2Text, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix2Text, In a map, will get to you in a minute.
 	IniRead, 2Suffix3Text, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix3Text, Still Interested?
@@ -624,7 +634,7 @@
 	IniRead, stashSuffix7, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffix7, Numpad7
 	IniRead, stashSuffix8, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffix8, Numpad8
 	IniRead, stashSuffix9, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffix9, Numpad9
-	
+
 	IniRead, stashSuffixTab1, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffixTab1, 1
 	IniRead, stashSuffixTab2, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffixTab2, 2
 	IniRead, stashSuffixTab3, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffixTab3, 3
@@ -647,7 +657,7 @@
 	IniRead, hotkeyControllerButtonSTART, %A_ScriptDir%\save\Settings.ini, Controller Keys, START, Tab
 	IniRead, hotkeyControllerButtonL3, %A_ScriptDir%\save\Settings.ini, Controller Keys, L3, Logout
 	IniRead, hotkeyControllerButtonR3, %A_ScriptDir%\save\Settings.ini, Controller Keys, R3, QuickPortal
-	
+
 	IniRead, hotkeyControllerJoystickRight, %A_ScriptDir%\save\Settings.ini, Controller Keys, JoystickRight, RButton
 
 	IniRead, YesTriggerUtilityKey, %A_ScriptDir%\save\Settings.ini, Controller, YesTriggerUtilityKey, 1
@@ -673,7 +683,7 @@
 Return
 }
 
-submit(){  
+submit(){
 updateEverything:
 	global
 	Thread, NoTimers, True    ;Critical
@@ -757,8 +767,8 @@ updateEverything:
 	If hotkeyOptions
 		hotkey,% hotkeyOptions, optionsCommand, Off
 	hotkey, IfWinActive, ahk_group POEGameGroup
-		
-	IfWinExist, ahk_group POEGameGroup 
+
+	IfWinExist, ahk_group POEGameGroup
 	{
 		Gui, Submit
 		Rescale()
@@ -832,7 +842,7 @@ updateEverything:
 	IniWrite, %HeistLockerStr%, %A_ScriptDir%\save\Settings.ini, FindText Strings, HeistLockerStr
 	IniWrite, %SkillUpStr%, %A_ScriptDir%\save\Settings.ini, FindText Strings, SkillUpStr
 
-	;~ Hotkeys 
+	;~ Hotkeys
 	IniWrite, %hotkeyOptions%, %A_ScriptDir%\save\Settings.ini, hotkeys, Options
 	IniWrite, %hotkeyAutoQuit%, %A_ScriptDir%\save\Settings.ini, hotkeys, AutoQuit
 	IniWrite, %hotkeyAutoFlask%, %A_ScriptDir%\save\Settings.ini, hotkeys, AutoFlask
@@ -844,7 +854,7 @@ updateEverything:
 	IniWrite, %hotkeyCraftBasic%, %A_ScriptDir%\save\Settings.ini, hotkeys, CraftBasic
 	IniWrite, %hotkeyCtrlClicker%, %A_ScriptDir%\save\Settings.ini, hotkeys, CtrlClicker
 	IniWrite, %hotkeyCtrlShiftClicker%, %A_ScriptDir%\save\Settings.ini, hotkeys, CtrlShiftClicker
-	IniWrite, %hotkeyGrabCurrency%, %A_ScriptDir%\save\Settings.ini, hotkeys, GrabCurrency 
+	IniWrite, %hotkeyGrabCurrency%, %A_ScriptDir%\save\Settings.ini, hotkeys, GrabCurrency
 	IniWrite, %hotkeyGetMouseCoords%, %A_ScriptDir%\save\Settings.ini, hotkeys, GetMouseCoords
 	IniWrite, %hotkeyPopFlasks%, %A_ScriptDir%\save\Settings.ini, hotkeys, PopFlasks
 	IniWrite, %hotkeyLogout%, %A_ScriptDir%\save\Settings.ini, hotkeys, Logout
@@ -860,16 +870,19 @@ updateEverything:
 	IniWrite, %hotkeyMainAttack%, %A_ScriptDir%\save\Settings.ini, hotkeys, MainAttack
 	IniWrite, %hotkeySecondaryAttack%, %A_ScriptDir%\save\Settings.ini, hotkeys, SecondaryAttack
 	IniWrite, %hotkeyTriggerMovement%, %A_ScriptDir%\save\Settings.ini, hotkeys, hotkeyTriggerMovement
-	
+
 	;Utility Keys
 	IniWrite, %hotkeyUp%,     %A_ScriptDir%\save\Settings.ini, Controller Keys, hotkeyUp
 	IniWrite, %hotkeyDown%,   %A_ScriptDir%\save\Settings.ini, Controller Keys, hotkeyDown
 	IniWrite, %hotkeyLeft%,   %A_ScriptDir%\save\Settings.ini, Controller Keys, hotkeyLeft
 	IniWrite, %hotkeyRight%,   %A_ScriptDir%\save\Settings.ini, Controller Keys, hotkeyRight
-	
+
 	;Grab Currency
 	IniWrite, %GrabCurrencyX%, %A_ScriptDir%\save\Settings.ini, Grab Currency, GrabCurrencyX
 	IniWrite, %GrabCurrencyY%, %A_ScriptDir%\save\Settings.ini, Grab Currency, GrabCurrencyY
+
+	;Crafting Bases
+	IniWrite, %YesStashCustom%, %A_ScriptDir%\save\Settings.ini, Custom  Settings, YesStashCustom
 
 	;Crafting Bases
 	IniWrite, %YesStashATLAS%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLAS
@@ -895,7 +908,7 @@ updateEverything:
 	IniWrite, %YesStashJ%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJ
 	IniWrite, %YesStashJCraftingIlvl%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJCraftingIlvl
 	IniWrite, %YesStashJCraftingIlvlMin%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashJCraftingIlvlMin
-	
+
 	IniWrite, %YesStashAJ%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashAJ
 	IniWrite, %YesStashAJCraftingIlvl%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashAJCraftingIlvl
 	IniWrite, %YesStashAJCraftingIlvlMin%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashAJCraftingIlvlMin
@@ -938,7 +951,7 @@ updateEverything:
 	IniWrite, %MMapItemRarity%, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MMapItemRarity
 	IniWrite, %MMapMonsterPackSize%, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, MMapMonsterPackSize
 	IniWrite, %EnableMQQForMagicMap%, %A_ScriptDir%\save\Settings.ini, Crafting Map Settings, EnableMQQForMagicMap
-	
+
 	;Stash Tab Management
 	IniWrite, %StashTabCurrency%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabCurrency
 	IniWrite, %StashTabMap%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabMap
@@ -946,7 +959,7 @@ updateEverything:
 	IniWrite, %StashTabGem%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGem
 	IniWrite, %StashTabGemQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabGemQuality
 	IniWrite, %StashTabFlaskQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskQuality
-	IniWrite, %StashTabFlaskAll%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskAll																						   
+	IniWrite, %StashTabFlaskAll%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabFlaskAll
 	IniWrite, %StashTabLinked%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabLinked
 	IniWrite, %StashTabBrickedMaps%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBrickedMaps
 	IniWrite, %StashTabUnique%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabUnique
@@ -975,7 +988,7 @@ updateEverything:
 	IniWrite, %StashTabYesGemQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemQuality
 	IniWrite, %StashTabYesGemSupport%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesGemSupport
 	IniWrite, %StashTabYesFlaskQuality%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskQuality
-	IniWrite, %StashTabYesFlaskAll%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskAll																								 
+	IniWrite, %StashTabYesFlaskAll%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesFlaskAll
 	IniWrite, %StashTabYesLinked%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesLinked
 	IniWrite, %StashTabYesUnique%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUnique
 	IniWrite, %StashTabYesUniqueRing%, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesUniqueRing
@@ -1035,7 +1048,7 @@ updateEverything:
 	IniWrite, %2Suffix7%, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix7
 	IniWrite, %2Suffix8%, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix8
 	IniWrite, %2Suffix9%, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix9
-	
+
 	IniWrite, %2Suffix1Text%, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix1Text
 	IniWrite, %2Suffix2Text%, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix2Text
 	IniWrite, %2Suffix3Text%, %A_ScriptDir%\save\Settings.ini, Chat Hotkeys, 2Suffix3Text
@@ -1057,7 +1070,7 @@ updateEverything:
 	IniWrite, %stashSuffix7%, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffix7
 	IniWrite, %stashSuffix8%, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffix8
 	IniWrite, %stashSuffix9%, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffix9
-	
+
 	IniWrite, %stashSuffixTab1%, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffixTab1
 	IniWrite, %stashSuffixTab2%, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffixTab2
 	IniWrite, %stashSuffixTab3%, %A_ScriptDir%\save\Settings.ini, Stash Hotkeys, stashSuffixTab3
@@ -1079,7 +1092,7 @@ updateEverything:
 	IniWrite, %hotkeyControllerButtonSTART%, %A_ScriptDir%\save\Settings.ini, Controller Keys, START
 	IniWrite, %hotkeyControllerButtonL3%, %A_ScriptDir%\save\Settings.ini, Controller Keys, L3
 	IniWrite, %hotkeyControllerButtonR3%, %A_ScriptDir%\save\Settings.ini, Controller Keys, R3
-	
+
 	IniWrite, %hotkeyControllerJoystickRight%, %A_ScriptDir%\save\Settings.ini, Controller Keys, JoystickRight
 
 	IniWrite, %YesTriggerUtilityKey%, %A_ScriptDir%\save\Settings.ini, Controller, YesTriggerUtilityKey
@@ -1123,7 +1136,7 @@ updateEverything:
 		WinActivate, ahk_group POEGameGroup
 		}
 	Thread, NoTimers, False    ;End Critical
-return  
+return
 }
 
 ; Settings Save/Load
@@ -1136,7 +1149,7 @@ Settings(name:="perChar",Action:="Load"){
 		For k, v in WR[name]
 			If (IsObject(obj[k]))
 				For l, w in v
-					If (obj[k].HasKey(l)) 
+					If (obj[k].HasKey(l))
 						WR[name][k][l] := obj[k][l]
 		obj := JSONtext := ""
 	} Else If (Action = "Save"){
@@ -1193,7 +1206,7 @@ Profile(args*){
 		For k, v in WR[Type]
 			If (IsObject(obj[k]))
 				For l, w in v
-					If (obj[k].HasKey(l)) 
+					If (obj[k].HasKey(l))
 						WR[Type][k][l] := obj[k][l]
 		If (Type = "perChar"){
 			If WR.perChar.Setting.profilesYesFlask

--- a/lib/SaveLoad.ahk
+++ b/lib/SaveLoad.ahk
@@ -302,7 +302,7 @@
 	;Crafting Bases Settings
 	;Loading Default List
 	sDefaultCustomStrings := JSON.Dump(DefaultCustomStrings)
-	IniRead, CustomStrings, %A_ScriptDir%\save\Settings.ini, Custom String Search, CustomString, %DefaultCustomStrings%
+	IniRead, CustomStrings, %A_ScriptDir%\save\Settings.ini, Custom String Settings, CustomString, %DefaultCustomStrings%
 	;Converting string to array
 	CustomStrings := JSON.Load(CustomStrings)
 
@@ -882,7 +882,7 @@ updateEverything:
 	IniWrite, %GrabCurrencyY%, %A_ScriptDir%\save\Settings.ini, Grab Currency, GrabCurrencyY
 
 	;Crafting Bases
-	IniWrite, %YesStashCustom%, %A_ScriptDir%\save\Settings.ini, Custom  Settings, YesStashCustom
+	IniWrite, %YesStashCustom%, %A_ScriptDir%\save\Settings.ini, Custom String Settings, YesStashCustom
 
 	;Crafting Bases
 	IniWrite, %YesStashATLAS%, %A_ScriptDir%\save\Settings.ini, Crafting Bases Settings, YesStashATLAS
@@ -1110,6 +1110,10 @@ updateEverything:
 	IniWrite, %YesNinjaDatabase%, %A_ScriptDir%\save\Settings.ini, Database, YesNinjaDatabase
 	IniWrite, %ForceMatch6Link%, %A_ScriptDir%\save\Settings.ini, Database, ForceMatch6Link
 	IniWrite, %ForceMatchGem20%, %A_ScriptDir%\save\Settings.ini, Database, ForceMatchGem20
+
+	;Crafting Bases Settings
+	sCustomStrings := JSON.Dump(CustomStrings)
+	IniWrite, %sCustomStrings%, %A_ScriptDir%\save\Settings.ini, Custom String Settings, CustomStrings
 
 	;Crafting Bases Settings
 	scraftingBasesT1 := ArrayToString(craftingBasesT1)

--- a/lib/gui/CustomStringsSearch.ahk
+++ b/lib/gui/CustomStringsSearch.ahk
@@ -1,0 +1,70 @@
+﻿; Wingman Crafting Labels - By DanMarzola
+CustomString:
+  Global CustomStringBase
+  StringTextList := ""
+  StringText := "str"
+  StringTab := "tab"
+  textList1 .= JSON.Dump(CustomStrings)
+  For k, v in CustomStrings
+  StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+
+  Gui, CustomString: New
+  Gui, CustomString: +AlwaysOnTop -MinimizeBox
+  Gui, CustomString: Add, Button, default gupdateEverything    x225 y180  w150 h23,   Save Configuration
+  Gui, CustomString: Add, Edit, vCustomStringBase xm+5 ym+28 w400
+  Gui, CustomString: Add, Edit, vCustomStringTaba xm+405 ym+28 w50
+  Gui, CustomString: Add, UpDown, vCustomStringTab w50
+  Gui, CustomString: Add, Tab2, vInventoryGuiTabs x3 y3 w600 h300 -wrap , Custom String Search
+  Gui, CustomString: Tab, Custom String Search
+    Gui, CustomString: Add, Edit, vCustomStringList ReadOnly y+28 w500 r8 , %StringTextList%
+    Gui, CustomString: Add, Button, gAddCustomStringBase y+8 w60 r2 center, Add String
+    Gui, CustomString: Add, Button, gRemoveCustomStringBase x+5 w60 r2 center, Remove String
+    Gui, CustomString: Add, Button, gResetCustomStringBase x+5 w60 r2 center, Reset All
+  Gui, CustomString: Show, , Edit Crafting Tiers
+Return
+
+AddCustomStringBase:
+  Gui, Submit, nohide
+  For k, v in CustomStrings
+  {
+    If HasVal(CustomStrings[k], CustomStringBase)
+        Return
+  }
+  NewStringNumber := (CustomStrings.MaxIndex() + 1)
+  CustomStrings[NewStringNumber] := []
+  CustomStrings[NewStringNumber][StringText] := CustomStringBase
+  CustomStrings[NewStringNumber][StringTab] := CustomStringTab
+
+  StringTextList := ""
+  For k, v in CustomStrings
+  StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+  GuiControl,, CustomStringList, %StringTextList%
+Return
+
+RemoveCustomStringBase:
+Gui, Submit, nohide
+For k, v in CustomStringsS
+{
+If (HasVal(CustomStrings[k], CustomStringBase))
+{
+  MsgBox % k
+CustomStrings.RemoveAt(k)
+}else{
+  Return
+}
+}
+
+StringTextList := ""
+For k, v in CustomStrings
+StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+GuiControl,, CustomStringList, %StringTextList%
+Return
+
+ResetCustomStringBase:
+  RegExMatch(A_GuiControl, "T" rxNum " Base", RxMatch )
+  craftingBasesT%RxMatch1% := DefaultcraftingBasesT%RxMatch1%.Clone()
+  textList := ""
+  For k, v in craftingBasesT%RxMatch1%
+        textList .= (!textList ? "" : ", ") v
+  GuiControl,, CustomStringList%RxMatch1%, %textList%
+Return

--- a/lib/gui/CustomStringsSearch.ahk
+++ b/lib/gui/CustomStringsSearch.ahk
@@ -4,16 +4,17 @@ Global CustomStringBase
 StringTextList := ""
 StringText := "str"
 StringTab := "tab"
-textList1 .= JSON.Dump(CustomStrings)
-For k, v in CustomStrings
-StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+For k, v in CustomStringBases
+{
+  StringTextList .= (!StringTextList ? "" : ", `r`n") . CustomStringBases[k][StringText] . ",  " . CustomStringBases[k][StringTab]
+}
 
 Gui, CustomString: New
 Gui, CustomString: +AlwaysOnTop -MinimizeBox
 Gui, CustomString: Add, Button, default gupdateEverything    x225 y180  w150 h23,   Save Configuration
 Gui, CustomString: Add, Edit, vCustomStringBase xm+5 ym+28 w400
 Gui, CustomString: Add, Edit, vCustomStringTaba xm+405 ym+28 w50
-Gui, CustomString: Add, UpDown, vCustomStringTab w50
+Gui, CustomString: Add, UpDown, vCustomStringTab Range1-200 w50
 Gui, CustomString: Add, Tab2, vInventoryGuiTabs x3 y3 w600 h300 -wrap , Custom String Settings
 Gui, CustomString: Tab, Custom String Settings
 Gui, CustomString: Add, Edit, vCustomStringList ReadOnly y+28 w500 r8 , %StringTextList%
@@ -30,10 +31,10 @@ StringTextList := ""
 NewCustomStrings := []
 CustomStringIndex := 1
 
-For k, v in CustomStrings
+For k, v in CustomStringBases
 {
   NewCustomString := []
-  ThisCustomString := CustomStrings[k]
+  ThisCustomString := CustomStringBases[k]
   If HasVal(ThisCustomString, CustomStringBase)
   {
     Return
@@ -52,7 +53,7 @@ For k, v in NewCustomStrings
 {
   StringTextList .= (!StringTextList ? "" : ", `r`n") . NewCustomStrings[k][StringText] . ",  " . NewCustomStrings[k][StringTab]
 }
-CustomStrings := NewCustomStrings.Clone()
+CustomStringBases := NewCustomStrings.Clone()
 GuiControl,, CustomStringList, %StringTextList%
 Return
 
@@ -62,10 +63,10 @@ Gui, Submit, nohide
 StringTextList := ""
 NewCustomStrings := []
 CustomStringIndex := 1
-For k, v in CustomStrings
+For k, v in CustomStringBases
 {
   NewCustomString := []
-  ThisCustomString := CustomStrings[k]
+  ThisCustomString := CustomStringBases[k]
   If !HasVal(ThisCustomString, CustomStringBase)
   {
     NewCustomStrings.InsertAt(CustomStringIndex, "" CustomStringIndex)
@@ -78,19 +79,19 @@ For k, v in NewCustomStrings
 {
   StringTextList .= (!StringTextList ? "" : ", `r`n") . NewCustomStrings[k][StringText] . ",  " . NewCustomStrings[k][StringTab]
 }
-CustomStrings := NewCustomStrings.Clone()
+CustomStringBases := NewCustomStrings.Clone()
 GuiControl,, CustomStringList, %StringTextList%
 Return
 
 ResetCustomStringBase:
 
 StringTextList := ""
-NewCustomStrings :=  JSON.Load(DefaultCustomStrings).Clone()
+NewCustomStrings :=  JSON.Load(DefaultCustomStringBases).Clone()
 
 For k, v in NewCustomStrings
 {
   StringTextList .= (!StringTextList ? "" : ", `r`n") . NewCustomStrings[k][StringText] . ",  " . NewCustomStrings[k][StringTab]
 }
-CustomStrings := NewCustomStrings.Clone()
+CustomStringBases := NewCustomStrings.Clone()
 GuiControl,, CustomStringList, %StringTextList%
 Return

--- a/lib/gui/CustomStringsSearch.ahk
+++ b/lib/gui/CustomStringsSearch.ahk
@@ -1,70 +1,95 @@
-﻿; Wingman Crafting Labels - By DanMarzola
+; Wingman Crafting Labels - By DanMarzola
 CustomString:
-  Global CustomStringBase
-  StringTextList := ""
-  StringText := "str"
-  StringTab := "tab"
-  textList1 .= JSON.Dump(CustomStrings)
-  For k, v in CustomStrings
-  StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+Global CustomStringBase
+StringTextList := ""
+StringText := "str"
+StringTab := "tab"
+textList1 .= JSON.Dump(CustomStrings)
+For k, v in CustomStrings
+StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
 
-  Gui, CustomString: New
-  Gui, CustomString: +AlwaysOnTop -MinimizeBox
-  Gui, CustomString: Add, Button, default gupdateEverything    x225 y180  w150 h23,   Save Configuration
-  Gui, CustomString: Add, Edit, vCustomStringBase xm+5 ym+28 w400
-  Gui, CustomString: Add, Edit, vCustomStringTaba xm+405 ym+28 w50
-  Gui, CustomString: Add, UpDown, vCustomStringTab w50
-  Gui, CustomString: Add, Tab2, vInventoryGuiTabs x3 y3 w600 h300 -wrap , Custom String Search
-  Gui, CustomString: Tab, Custom String Search
-    Gui, CustomString: Add, Edit, vCustomStringList ReadOnly y+28 w500 r8 , %StringTextList%
-    Gui, CustomString: Add, Button, gAddCustomStringBase y+8 w60 r2 center, Add String
-    Gui, CustomString: Add, Button, gRemoveCustomStringBase x+5 w60 r2 center, Remove String
-    Gui, CustomString: Add, Button, gResetCustomStringBase x+5 w60 r2 center, Reset All
-  Gui, CustomString: Show, , Edit Crafting Tiers
+Gui, CustomString: New
+Gui, CustomString: +AlwaysOnTop -MinimizeBox
+Gui, CustomString: Add, Button, default gupdateEverything    x225 y180  w150 h23,   Save Configuration
+Gui, CustomString: Add, Edit, vCustomStringBase xm+5 ym+28 w400
+Gui, CustomString: Add, Edit, vCustomStringTaba xm+405 ym+28 w50
+Gui, CustomString: Add, UpDown, vCustomStringTab w50
+Gui, CustomString: Add, Tab2, vInventoryGuiTabs x3 y3 w600 h300 -wrap , Custom String Search
+Gui, CustomString: Tab, Custom String Search
+Gui, CustomString: Add, Edit, vCustomStringList ReadOnly y+28 w500 r8 , %StringTextList%
+Gui, CustomString: Add, Button, gAddCustomStringBase y+8 w60 r2 center, Add String
+Gui, CustomString: Add, Button, gRemoveCustomStringBase x+5 w60 r2 center, Remove String
+Gui, CustomString: Add, Button, gResetCustomStringBase x+5 w60 r2 center, Reset All
+Gui, CustomString: Show, , Edit Crafting Tiers
 Return
 
 AddCustomStringBase:
-  Gui, Submit, nohide
-  For k, v in CustomStrings
-  {
-    If HasVal(CustomStrings[k], CustomStringBase)
-        Return
-  }
-  NewStringNumber := (CustomStrings.MaxIndex() + 1)
-  CustomStrings[NewStringNumber] := []
-  CustomStrings[NewStringNumber][StringText] := CustomStringBase
-  CustomStrings[NewStringNumber][StringTab] := CustomStringTab
+Gui, Submit, nohide
 
-  StringTextList := ""
-  For k, v in CustomStrings
+NewCustomStrings := []
+CustomStringIndex := 1
+For k, v in CustomStrings
+{
+  NewCustomString := []
+  ThisCustomString := CustomStrings[k]
+  If HasVal(ThisCustomString, CustomStringBase)
+  {
+    MsgBox, Already in your list!
+    Return
+  }
+  NewCustomStrings.InsertAt(CustomStringIndex, "" CustomStringIndex)
+  NewCustomStrings[CustomStringIndex] := ThisCustomString
+
   StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
-  GuiControl,, CustomStringList, %StringTextList%
+  CustomStringIndex := CustomStringIndex+1
+}
+
+CustomStringBaseArr := []
+
+CustomStringBaseArr[StringText] := CustomStringBase
+CustomStringBaseArr[StringTab] := CustomStringTab
+
+NewCustomStrings.Push(CustomStringBaseArr)
+
+
+GuiControl,, CustomStringList, %StringTextList%
 Return
 
 RemoveCustomStringBase:
 Gui, Submit, nohide
-For k, v in CustomStringsS
+
+NewCustomStrings := []
+CustomStringIndex := 1
+For k, v in CustomStrings
 {
-If (HasVal(CustomStrings[k], CustomStringBase))
-{
-  MsgBox % k
-CustomStrings.RemoveAt(k)
-}else{
-  Return
-}
+  NewCustomString := []
+  ThisCustomString := CustomStrings[k]
+  If !HasVal(ThisCustomString, CustomStringBase)
+  {
+    NewCustomStrings.InsertAt(CustomStringIndex, "" CustomStringIndex)
+    NewCustomStrings[CustomStringIndex] := ThisCustomString
+
+    StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+    CustomStringIndex := CustomStringIndex+1
+  }
 }
 
-StringTextList := ""
-For k, v in CustomStrings
-StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+CustomStringBaseArr := []
+
+CustomStringBaseArr[StringText] := CustomStringBase
+CustomStringBaseArr[StringTab] := CustomStringTab
+
 GuiControl,, CustomStringList, %StringTextList%
 Return
 
 ResetCustomStringBase:
-  RegExMatch(A_GuiControl, "T" rxNum " Base", RxMatch )
-  craftingBasesT%RxMatch1% := DefaultcraftingBasesT%RxMatch1%.Clone()
-  textList := ""
-  For k, v in craftingBasesT%RxMatch1%
-        textList .= (!textList ? "" : ", ") v
-  GuiControl,, CustomStringList%RxMatch1%, %textList%
+RegExMatch(A_GuiControl, "T" rxNum " Base", RxMatch )
+CustomStringsRes := DefaultCustomStrings.Clone()
+textList := ""
+For k, v in CustomStringsRes
+{
+  StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+}
+}
+GuiControl,, CustomStringList%RxMatch1%, %textList%
 Return

--- a/lib/gui/CustomStringsSearch.ahk
+++ b/lib/gui/CustomStringsSearch.ahk
@@ -90,6 +90,5 @@ For k, v in CustomStringsRes
 {
   StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
 }
-}
 GuiControl,, CustomStringList%RxMatch1%, %textList%
 Return

--- a/lib/gui/CustomStringsSearch.ahk
+++ b/lib/gui/CustomStringsSearch.ahk
@@ -14,8 +14,8 @@ Gui, CustomString: Add, Button, default gupdateEverything    x225 y180  w150 h23
 Gui, CustomString: Add, Edit, vCustomStringBase xm+5 ym+28 w400
 Gui, CustomString: Add, Edit, vCustomStringTaba xm+405 ym+28 w50
 Gui, CustomString: Add, UpDown, vCustomStringTab w50
-Gui, CustomString: Add, Tab2, vInventoryGuiTabs x3 y3 w600 h300 -wrap , Custom String Search
-Gui, CustomString: Tab, Custom String Search
+Gui, CustomString: Add, Tab2, vInventoryGuiTabs x3 y3 w600 h300 -wrap , Custom String Settings
+Gui, CustomString: Tab, Custom String Settings
 Gui, CustomString: Add, Edit, vCustomStringList ReadOnly y+28 w500 r8 , %StringTextList%
 Gui, CustomString: Add, Button, gAddCustomStringBase y+8 w60 r2 center, Add String
 Gui, CustomString: Add, Button, gRemoveCustomStringBase x+5 w60 r2 center, Remove String
@@ -26,38 +26,40 @@ Return
 AddCustomStringBase:
 Gui, Submit, nohide
 
+StringTextList := ""
 NewCustomStrings := []
 CustomStringIndex := 1
+
 For k, v in CustomStrings
 {
   NewCustomString := []
   ThisCustomString := CustomStrings[k]
   If HasVal(ThisCustomString, CustomStringBase)
   {
-    MsgBox, Already in your list!
     Return
   }
   NewCustomStrings.InsertAt(CustomStringIndex, "" CustomStringIndex)
   NewCustomStrings[CustomStringIndex] := ThisCustomString
-
-  StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
   CustomStringIndex := CustomStringIndex+1
 }
 
 CustomStringBaseArr := []
-
 CustomStringBaseArr[StringText] := CustomStringBase
 CustomStringBaseArr[StringTab] := CustomStringTab
-
 NewCustomStrings.Push(CustomStringBaseArr)
 
-
+For k, v in NewCustomStrings
+{
+  StringTextList .= (!StringTextList ? "" : ", `r`n") . NewCustomStrings[k][StringText] . ",  " . NewCustomStrings[k][StringTab]
+}
+CustomStrings := NewCustomStrings.Clone()
 GuiControl,, CustomStringList, %StringTextList%
 Return
 
 RemoveCustomStringBase:
 Gui, Submit, nohide
 
+StringTextList := ""
 NewCustomStrings := []
 CustomStringIndex := 1
 For k, v in CustomStrings
@@ -68,27 +70,27 @@ For k, v in CustomStrings
   {
     NewCustomStrings.InsertAt(CustomStringIndex, "" CustomStringIndex)
     NewCustomStrings[CustomStringIndex] := ThisCustomString
-
-    StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
     CustomStringIndex := CustomStringIndex+1
   }
 }
 
-CustomStringBaseArr := []
-
-CustomStringBaseArr[StringText] := CustomStringBase
-CustomStringBaseArr[StringTab] := CustomStringTab
-
+For k, v in NewCustomStrings
+{
+  StringTextList .= (!StringTextList ? "" : ", `r`n") . NewCustomStrings[k][StringText] . ",  " . NewCustomStrings[k][StringTab]
+}
+CustomStrings := NewCustomStrings.Clone()
 GuiControl,, CustomStringList, %StringTextList%
 Return
 
 ResetCustomStringBase:
-RegExMatch(A_GuiControl, "T" rxNum " Base", RxMatch )
-CustomStringsRes := DefaultCustomStrings.Clone()
-textList := ""
-For k, v in CustomStringsRes
+
+StringTextList := ""
+NewCustomStrings :=  JSON.Load(DefaultCustomStrings).Clone()
+
+For k, v in NewCustomStrings
 {
-  StringTextList .= (!StringTextList ? "" : ", `r`n") CustomStrings[k][StringText] . ",  " . CustomStrings[k][StringTab]
+  StringTextList .= (!StringTextList ? "" : ", `r`n") . NewCustomStrings[k][StringText] . ",  " . NewCustomStrings[k][StringTab]
 }
-GuiControl,, CustomStringList%RxMatch1%, %textList%
+CustomStrings := NewCustomStrings.Clone()
+GuiControl,, CustomStringList, %StringTextList%
 Return

--- a/lib/gui/WR_Menu.ahk
+++ b/lib/gui/WR_Menu.ahk
@@ -39,7 +39,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Checkbox, gSaveGeneral   vYesSpecial5Link       Checked%YesSpecial5Link%       y+8    , Give 5 link Special Type?
       Gui, Inventory: Add, Checkbox, gSaveGeneral   vYesOpenStackedDeck    Checked%YesOpenStackedDeck%    y+8    , Open Stacked Decks?
       Gui, Inventory: Add, Checkbox, gSaveGeneral   vYesVendorDumpItems    Checked%YesVendorDumpItems%    y+8    , Vendor Dump Tab Items?
-      
+
       Gui, Inventory: Font, Bold s9 cBlack, Arial
       Gui, Inventory: Add, GroupBox,         Section      w370 h100      xm+180   ym+25,         Scroll, Gem and Currency Locations
       Gui, Inventory: Font
@@ -53,7 +53,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Button,      gWR_Update vWR_Btn_Locate_GrabCurrency                     xs+173       ys+31  h17            , Locate
       Gui, Inventory: Add, Button, gRestockMenu r2 x+16    ys+30, Inventory Slot`n`rManagement
       Gui, Inventory: Add, Checkbox, gSaveGeneral   vEnableRestock    Checked%EnableRestock%  xp  y+8   , Enable Restock?
-      
+
       Gui, Inventory: Add, Text,                   xs+84   ys+25    h72 0x11
       Gui, Inventory: Add, Text,                   x+33             h72 0x11
       Gui, Inventory: Add, Text,                   x+33             h72 0x11
@@ -67,7 +67,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Text, xs+5 y+11 hwndPredictivePriceHWND, Price Rares?
       Gui, Inventory: Add, DropDownList, gUpdateExtra vYesPredictivePrice x+2 yp-3 w45 h13 r5, Off|Low|Avg|High
       GuiControl,Inventory: ChooseString, YesPredictivePrice, %YesPredictivePrice%
-      
+
       Gui, Inventory: Font, s18
       Gui, Inventory: Add, Text, x+1 yp-3 cC39F22, `%
       Gui, Inventory: Add, Text, vYesPredictivePrice_Percent_Val x+0 yp w40 cC39F22 center, %YesPredictivePrice_Percent_Val%
@@ -145,7 +145,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
       Gui, Inventory: Add, UpDown,Range1-99 gSaveStashTabs vStashTabMiscMapItems x+0 yp hp ,  %StashTabMiscMapItems%
       Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesMiscMapItems  Checked%StashTabYesMiscMapItems% x+5 yp+4, Enable
-      
+
       ; Second column Gui - GEMS
 
       Gui, Inventory: Font, Bold s8 cBlack, Arial
@@ -198,7 +198,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
       Gui, Inventory: Add, UpDown, Range1-99  x+0 yp hp gSaveStashTabs vStashTabCrafting , %StashTabCrafting%
       Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesCrafting Checked%StashTabYesCrafting% x+5 yp+4, Enable
-      
+
       Gui, Inventory: Font, Bold s8 cBlack, Arial
       Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , Dump
       Gui, Inventory: Font,
@@ -233,7 +233,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
       Gui, Inventory: Add, UpDown, Range1-99 x+0 yp hp gSaveStashTabs vStashTabFlaskQuality , %StashTabFlaskQuality%
       Gui, Inventory: Add, Checkbox, gSaveStashTabs  vStashTabYesFlaskQuality Checked%StashTabYesFlaskQuality% x+5 yp+4, Enable
-	  
+
 	  Gui, Inventory: Font, Bold s8 cBlack, Arial
       Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , Unquality Flask
       Gui, Inventory: Font,
@@ -264,7 +264,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Font, Bold s9 cBlack, Arial
       Gui, Inventory: Add, GroupBox,             w180 h160    section    xs   y+10,         Map/Contract Options
       Gui, Inventory: Font,
-      Gui, Inventory: Add, DropDownList, w40 gUpdateExtra  vYesSkipMaps_eval xs+5 yp+18 , % ">=|<=" 
+      Gui, Inventory: Add, DropDownList, w40 gUpdateExtra  vYesSkipMaps_eval xs+5 yp+18 , % ">=|<="
       GuiControl,Inventory: ChooseString, YesSkipMaps_eval, %YesSkipMaps_eval%
       Gui, Inventory: Add, DropDownList, w40 gUpdateExtra  vYesSkipMaps x+3 yp , 0|1|2|3|4|5|6|7|8|9|10|11|12
       GuiControl,Inventory: ChooseString, YesSkipMaps, %YesSkipMaps%
@@ -274,7 +274,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Checkbox, gUpdateExtra  vYesSkipMaps_rare Checked%YesSkipMaps_rare%   xs+5 y+8        , Skip Rare?
       Gui, Inventory: Add, Checkbox, gUpdateExtra  vYesSkipMaps_unique Checked%YesSkipMaps_unique%   x+0 yp       , Skip Unique?
       Gui, Inventory: Add, Text, xs+5 y+8 , Skip Maps => Tier
-      Gui, Inventory: Add, Edit, Number w40 x+5 yp-3 
+      Gui, Inventory: Add, Edit, Number w40 x+5 yp-3
       Gui, Inventory: Add, UpDown, center hp w40 range1-16 gUpdateExtra vYesSkipMaps_tier , %YesSkipMaps_tier%
 
       Gui, Inventory: Add, Checkbox, gUpdateExtra  vBrickedWhenCorrupted Checked%BrickedWhenCorrupted% xs+5 y+8, Only consider a map to be`rbricked if it's corrupted
@@ -367,7 +367,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, UpDown,Range1-99 gSaveStashTabs  vStashTabMap x+0 yp hp ,  %StashTabMap%
       Gui, Inventory: Add, Slider, range0-2 center noticks gSaveStashTabs vStashTabYesMap x+5 yp-5 w90 h20, %StashTabYesMap%
       Gui, Inventory: Add, Text,  xp yp+22 w90 center vMapEditText, Disable Type
-      
+
       ; Unique
       Gui, Inventory: Font, Bold s8 cBlack, Arial
       Gui, Inventory: Add, GroupBox, w145 h50 xs yp+20 , Unique
@@ -383,9 +383,9 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Font, Bold s8 cBlack, Arial
       Gui, Inventory: Add, GroupBox, Section w200 h100 x+50 ys , Intructions:
       Gui, Inventory: Font,
-      Gui, Inventory: Add, Text, xs+10 yp+15 +Wrap w180, - You can enable Currency Affinity 
+      Gui, Inventory: Add, Text, xs+10 yp+15 +Wrap w180, - You can enable Currency Affinity
       Gui, Inventory: Add, Text, xs+10 yp+15 +Wrap w180, and set the stash for other functions
-      Gui, Inventory: Add, Text, xs+10 yp+15 +Wrap w180, - CLF will take priority over Affinity 
+      Gui, Inventory: Add, Text, xs+10 yp+15 +Wrap w180, - CLF will take priority over Affinity
       Gui, Inventory: Add, Text, xs+10 yp+15 +Wrap w180, - Use slider to choose logic type
       Gui, Inventory: Add, Text, xs+10 yp+15 +Wrap w180, - Enable overflow Unique tabs
 
@@ -564,6 +564,12 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, UpDown, Range1-100  hp gUpdateExtra vYesStashJewelleryCraftingIlvlMin , %YesStashJewelleryCraftingIlvlMin%
       Gui, Inventory: Add, Button, gCustomCrafting xs+10 y+5  w120,   Edit Crafting Bases
 
+      Gui, Inventory: Font, Bold s9 cBlack, Arial
+      Gui, Inventory: Add, GroupBox,             w150 h90    section    xs+160 ym+25,         Custom Strings
+      Gui, Inventory: Font,
+      Gui, Inventory: Add, Checkbox, gUpdateExtra  YesStashCustom Checked%YesStashCustom%    xs+5  ys+18 , Enable ?
+      Gui, Inventory: Add, Button, gCustomString xs+10 y+5  w120,   Edit Custom Strings
+
     }
     Gui, Inventory: show , w600 h500, Inventory Settings
   }
@@ -583,7 +589,7 @@ WR_Menu(Function:="",Var*){
       Gui, Crafting: Add, Tab2, vCraftingGuiTabs x3 y3 w675 h555 -wrap , Map Crafting|Basic Crafting
 
       Gui, Crafting: Tab, Map Crafting
-        
+
         MapMethodList := "Disable|Transmutation+Augmentation|Alchemy|Chisel+Alchemy|Chisel+Alchemy+Vaal|Binding|Chisel+Binding|Chisel+Binding+Vaal|Hybrid|Chisel+Hybrid|Chisel+Hybrid+Vaal"
         MapTierList := "1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16"
         MapSetValue := "1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|61|62|63|64|65|66|67|68|69|70|71|72|73|74|75|76|77|78|79|80|81|82|83|84|85|86|87|88|89|90|91|92|93|94|95|96|97|98|99|100"
@@ -642,17 +648,17 @@ WR_Menu(Function:="",Var*){
           Gui, Crafting: Add, Checkbox, vMICSC xs+290 ys+40 Checked%MICSC%,  Monsters Have # Increased Critical Strike Chance
           Gui, Crafting: Add, Checkbox, vMSCAT xs+290 ys+60 Checked%MSCAT%, Monsters Skills Chain # Additional Times
           Gui, Crafting: Add, Checkbox, vMFAProjectiles xs+290 ys+80 Checked%MFAProjectiles%, Monsters Fire # Additional Projectiles
-          Gui, Crafting: Add, Checkbox, vMinusMPR xs+290 ys+100 Checked%MinusMPR%, Reduced # Maximum Player Resistances 
-          Gui, Crafting: Add, Checkbox, vPCDodgeUnlucky xs+290 ys+120 Checked%PCDodgeUnlucky%, Player Chance to Dodge is Unlucky  
+          Gui, Crafting: Add, Checkbox, vMinusMPR xs+290 ys+100 Checked%MinusMPR%, Reduced # Maximum Player Resistances
+          Gui, Crafting: Add, Checkbox, vPCDodgeUnlucky xs+290 ys+120 Checked%PCDodgeUnlucky%, Player Chance to Dodge is Unlucky
           Gui, Crafting: Add, Checkbox, vMHAccuracyRating xs+290 ys+140 Checked%MHAccuracyRating%, Monsters Have # Increased Accuracy Rating
           Gui, Crafting: Add, Checkbox, vPHLessArmour xs+290 ys+160 Checked%PHLessArmour%, Players Have # Less Armour
           Gui, Crafting: Add, Button, xs+215 ys+200 w200,  Custom Undesired Mods
-          
+
 
           Gui, Crafting: Font, Bold
           Gui, Crafting: Font, Bold s9 cBlack, Arial
         Gui, Crafting: Add,GroupBox,Section w200 h130 x320 y50, Minimum Map Qualities:
-          Gui, Crafting: Font, 
+          Gui, Crafting: Font,
           Gui, Crafting: Font,s8
 
           Gui, Crafting: Add, Edit, number limit2 xs+15 yp+18 w40
@@ -695,7 +701,7 @@ WR_Menu(Function:="",Var*){
         Gui, Crafting: Font, Bold s12 cRed, Arial
         Gui, Crafting: Add, Text,% "xs+25 y+20"
         Gui, Crafting: Add, UpDown,gSaveBasicCraft Range0-6 vBasicCraftR, % BasicCraftR
-        Gui, Crafting: Add, Text, x+5 yp, R 
+        Gui, Crafting: Add, Text, x+5 yp, R
         Gui, Crafting: Font, Bold s12 cGreen, Arial
         Gui, Crafting: Add, Text,% "x+25 yp"
         Gui, Crafting: Add, UpDown,gSaveBasicCraft Range0-6 vBasicCraftG, % BasicCraftG
@@ -744,7 +750,7 @@ WR_Menu(Function:="",Var*){
       Gui, Strings: +AlwaysOnTop -MinimizeBox
       ;Save Setting
       ; Gui, Add, Button, default gupdateEverything    x295 y470  w150 h23,   Save Configuration
-      
+
       Gui, Strings: Add, Button,      gLaunchSite     x295 y470           h23,   Website
       Gui, Strings: Add, Button,      gft_Start     x+5           h23,   FindText Gui (capture)
       Gui, Strings: Font, Bold cBlack
@@ -753,7 +759,7 @@ WR_Menu(Function:="",Var*){
       Gui, Strings: Font,
 
     Gui, Strings: Tab, General
-      Gui, Strings: Add, Button, xs+1 ys+1 w1 h1, 
+      Gui, Strings: Add, Button, xs+1 ys+1 w1 h1,
       Gui, Strings: +Delimiter?
       Gui, Strings: Add, Text, xs+10 ys+25 section, OHB 1 pixel bar - Only Adjust if not 1080 Height
       Gui, Strings: Add, ComboBox, xp y+8 w220 vHealthBarStr gUpdateStringEdit , %HealthBarStr%??"%1080_HealthBarStr%"?"%1440_HealthBarStr%"?"%1440_HealthBarStr_Alt%"?"%1050_HealthBarStr%"
@@ -771,7 +777,7 @@ WR_Menu(Function:="",Var*){
       Gui, Strings: +Delimiter|
 
     Gui, Strings: Tab, Vendor
-      Gui, Strings: Add, Button, Section x20 y30 w1 h1, 
+      Gui, Strings: Add, Button, Section x20 y30 w1 h1,
       Gui, Strings: +Delimiter?
       Gui, Strings: Add, Text, xs+10 ys+25 section, Capture of the Hideout vendor nameplate
       Gui, Strings: Add, ComboBox, y+8 w280 vVendorStr gUpdateStringEdit , %VendorStr%??"%1080_MasterStr%"?"%1080_NavaliStr%"?"%1080_HelenaStr%"?"%1080_ZanaStr%"?"%2160_NavaliStr%"?"%1440_ZanaStr%"?"%1440_NavaliStr%"?"%1050_MasterStr%"?"%1050_NavaliStr%"?"%1050_HelenaStr%"?"%1050_ZanaStr%"?"%768_NavaliStr%"?"%1440_JunStr%"
@@ -797,7 +803,7 @@ WR_Menu(Function:="",Var*){
       Gui, Strings: Add, ComboBox, y+8 w280 vVendorHarbourStr gUpdateStringEdit , %VendorHarbourStr%??"%1080_FenceStr%"
       Gui, Strings: +Delimiter|
     Gui, Strings: Tab, Debuff
-      Gui, Strings: Add, Button, Section x20 y30 w1 h1, 
+      Gui, Strings: Add, Button, Section x20 y30 w1 h1,
       Gui, Strings: +Delimiter?
 
       Gui, Strings: Add, Text, xs+10 ys+25 section, Curse - Elemental Weakness
@@ -963,10 +969,10 @@ WR_Menu(Function:="",Var*){
       Gui, Controller: New
       Gui, Controller: +AlwaysOnTop -MinimizeBox
       DefaultButtons := [ "ItemSort","QuickPortal","PopFlasks","GemSwap","Logout","LButton","RButton","MButton","q","w","e","r","t"]
-      textList= 
+      textList=
       For k, v in DefaultButtons
         textList .= (!textList ? "" : "|") v
-      
+
       Gui, Controller: Add, Picture, xm ym+20 w600 h400 +0x4000000, %A_ScriptDir%\data\Controller.png
 
       Gui, Controller: Add, Checkbox,  section  xp y+-10          vYesMovementKeys Checked%YesMovementKeys%                     , Use Move Keys?
@@ -1330,7 +1336,7 @@ WR_Menu(Function:="",Var*){
       Gui, hkStash: Add, Edit, Number y+5 w40
       Gui, hkStash: Add, UpDown, Range1-64  x+0 hp vstashSuffixTab9 , %stashSuffixTab9%
     }
-    
+
     Gui, hkStash: Show
 
   }
@@ -1370,7 +1376,7 @@ WR_Menu(Function:="",Var*){
     ; Naming convention: WR_GuiElementType_FunctionName_ExtraStuff_AfterFunctionName
     ; Function = FunctionName, Var[1] = GuiElementType, Var[2] = ExtraStuff_AfterFunctionName
     WR_Menu(BtnStr[2],BtnStr[1],BtnStr[3])
-  }  
+  }
   Return
 
 
@@ -1412,7 +1418,7 @@ WR_Menu(Function:="",Var*){
     CheckGamestates:= True
     mainmenuGameLogicState(True)
   return
-  
+
   GlobeGuiClose:
   GlobeGuiEscape:
     GlobeActive := False

--- a/lib/gui/WR_Menu.ahk
+++ b/lib/gui/WR_Menu.ahk
@@ -567,7 +567,7 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Font, Bold s9 cBlack, Arial
       Gui, Inventory: Add, GroupBox,             w150 h90    section    xs+160 ym+25,         Custom Strings
       Gui, Inventory: Font,
-      Gui, Inventory: Add, Checkbox, gUpdateExtra  YesStashCustom Checked%YesStashCustom%    xs+5  ys+18 , Enable ?
+      Gui, Inventory: Add, Checkbox, gUpdateExtra  vYesStashCustom Checked%YesStashCustom%    xs+5  ys+18 , Enable ?
       Gui, Inventory: Add, Button, gCustomString xs+10 y+5  w120,   Edit Custom Strings
 
     }
@@ -653,7 +653,7 @@ WR_Menu(Function:="",Var*){
           Gui, Crafting: Add, Checkbox, vMHAccuracyRating xs+290 ys+140 Checked%MHAccuracyRating%, Monsters Have # Increased Accuracy Rating
           Gui, Crafting: Add, Checkbox, vPHLessArmour xs+290 ys+160 Checked%PHLessArmour%, Players Have # Less Armour
           Gui, Crafting: Add, Button, xs+215 ys+200 w200 gCustomUndesirableMods,  Custom Undesirable Mods
-          
+
 
           Gui, Crafting: Font, Bold
           Gui, Crafting: Font, Bold s9 cBlack, Arial

--- a/lib/ref/CBMatchingGUI.ahk
+++ b/lib/ref/CBMatchingGUI.ahk
@@ -45,6 +45,24 @@ Tab::
 	}
 return
 
+#If WinActive("Edit Custom Strings Here")
+Tab::
+	Gui, submit, NoHide
+	;...context specific stuff
+	KeyWait, Tab
+	GuiControlGet, OutputVarE, CustomCrafting:Focus
+	GuiControlGet, varname, CustomCrafting:Focusv
+	If ( InStr(OutputVarE,"SysTabControl") || InStr(OutputVarE,"Button") || !InStr(varname, "CustomCrafting") )
+		Return
+	OutputVar := StrReplace(OutputVarE, "Edit", "ComboBox")
+	ControlGet, hCBe, hwnd,,%OutputVarE%
+	ControlGet, hCB, hwnd,,%OutputVar%
+	if (!WinExist("ahk_id "hCBMatchesGui) && hCB && hCBe) {
+		CreateCBMatchingGUI(hCB, "Edit Custom Strings Here")
+	}
+return
+
+
 CreateCBMatchingGUI(hCB, parentWindowTitle) {
 ;--------------------------------------------------------------------------------
 	Global CBMatchingGUI := {}
@@ -52,7 +70,7 @@ CreateCBMatchingGUI(hCB, parentWindowTitle) {
 	Gui, +HWNDhCBMatchesGui +Delimiter`n
 	Gui, Margin, 0, 0
 	Gui, Font, s14 q5
-	
+
 	; get Parent ComboBox info
 	WinGetPos, cX, cY, cW, cH, % "ahk_id " hCB
 	ControlGet, CBList, List,,, % "ahk_id " hCB
@@ -64,18 +82,18 @@ CreateCBMatchingGUI(hCB, parentWindowTitle) {
 	GuiControl,, %hEdit%, %CBChoice%
 	Gui, Add, ListBox, % "+HWNDhLB xp y+0 wp" " R20", % CBList
 	GuiControl, ChooseString, %hLB%, %CBChoice%
-	
+
 	CBMatchingGUI.hwnd := hCBMatchesGui
 	CBMatchingGUI.hEdit := hEdit
 	CBMatchingGUI.hLB := hLB
 	CBMatchingGUI.hParentCB := hCB
 	CBMatchingGUI.parentCBList := CBList
 	CBMatchingGUI.parentWindowTitle := parentWindowTitle
-	
+
 	gFunction := Func("CBMatching").Bind(CBMatchingGUI)
 	tFunction := Func("FuncTimer").Bind(gFunction,400)
 	GuiControl, +g, %hEdit%, %tFunction%
-	
+
 	Gui, Show, % "x"cX-50 " y"cY-5 " ", % "CBMatchingGUI"
 	ControlFocus,, % "ahk_id "CBMatchingGUI.hEdit
 	SetTimer, DestroyCBMatchingGUI, 80
@@ -142,10 +160,10 @@ CBMatching(ByRef CBMatchingGUI) { ; ByRef object generated at the GUI creation
 		if (MatchCount = 1) {
 			UniqueMatch := Matches
 			GuiControl, ChooseString, % CBMatchingGUI.hLB, %UniqueMatch%
-		} 
+		}
 		else
 			GuiControl, Choose, % CBMatchingGUI.hLB, 1
-	} 
+	}
 	else
 		GuiControl,, % CBMatchingGUI.hLB, `n<! No Match !>
 }
@@ -154,7 +172,7 @@ CBMatching(ByRef CBMatchingGUI) { ; ByRef object generated at the GUI creation
 DestroyCBMatchingGUI() {
 ;--------------------------------------------------------------------------------
 	Global CBMatchingGUI ; global object created with the CBMatchingGUI
-	
+
 	if (!WinActive("Ahk_id " CBMatchingGUI.hwnd) and WinExist("ahk_id " CBMatchingGUI.hwnd)) {
 		Gui, % CBMatchingGUI.hwnd ":Destroy"
 		SetTimer, DestroyCBMatchingGUI, Delete
@@ -165,7 +183,7 @@ DestroyCBMatchingGUI() {
 setCBMatchingGUILBChoice(CBMatchingGUI) {
 ;--------------------------------------------------------------------------------
 	; get ListBox choice
-	GuiControlGet, LBMatchesSelectedChoice,, % CBMatchingGUI.hLB 
+	GuiControlGet, LBMatchesSelectedChoice,, % CBMatchingGUI.hLB
 	; set choice in parent ComboBox
 	Control, ChooseString, %LBMatchesSelectedChoice%,,% "ahk_id "CBMatchingGUI.hParentCB
 	; set focus to Parent ComboBox, this will destroy matching GUI


### PR DESCRIPTION
I have created this new amazing feature, On "Inventory Sorting", "Crafting Bases" I created a "Custom Strings" box.

You can add any custom string to a list such as "Stone Hammer" and the tab number you want to this item to go to. I made it very high on the que that way if you want to move say "Orbs of Chance" to tab 3, even with affinity enabled it will work (and ignore affinity tabs I believe).

This code is very ugly and needs to be cleaned but I have just tested it now and it works good. Also there are alot of line spacing changes I think.

Please let me know what changes I need to make to achieve a Pull!

This feature is amazing try it out. You could literally ignore every other Inventory sorting field, checkbox etc, and fill out this list (altough my main purpose was primarily sorting leveling crafting such as flasks, certain gems, etc)


The only bug right now i see that if you enter low number  (such as 5), It wont be added because this is conflicting with the index of the json somehow. I don't see what you want to sort 1-100 (integer) into a slot.

It pulls from **item name** but eventually we could code this similar to search values in stash such as "ilvl:x" so all items that ilevel would get moved, etc etc etc.


Never lose a "of Staunching" / minion flask again, Make sure they are always where you want!