### PR TITLE
New feature "trigger with sample string & resource"

### DIFF
--- a/lib/ScriptObject.ahk
+++ b/lib/ScriptObject.ahk
@@ -23,7 +23,7 @@ WR.perChar.Setting := {"typeLife":"1", "typeHybrid":"0", "typeES":"0", "typeEldr
 		. ".108104040k60E0k30M303UQ1UA0C1kC0s0s70w7U3US3kC040k70k0E30M1011hzw4049zwQE0F3zVt01SLwDw0DsjUzk0zmS7zkDz9QTk1Xw3lk001sD60oQ3UwED1w23k1w7s0DUDkTk3B1z1zUBo5y7z26U0sTk0H00lw0A0017U2k000w0053w/c00kDwj3k01zMMzU0Dptrz01wFgzzU7U2rzzwQ0Tzzzllz7zzzzz03zzzzU003zz008"
 	, "channelrepressStack":"|<5 stacks>*52$8.zsC3bsS3wz7nwsSTzs"
 	, "autominesEnable":"0", "autominesBoomDelay":"500", "autominesPauseDoubleTapSpeed":"300", "autominesPauseSingleTap":"2", "autominesSmokeDashEnable":"0", "autominesSmokeDashKey":"q"
-	, "autolevelgemsEnable":"0", "autolevelgemsWait":"0" 
+	, "autolevelgemsEnable":"0", "autolevelgemsWait":"0"
 	, "swap1AltWeapon":"0", "swap1Item":"0", "swap1Xa":"0", "swap1Ya":"0", "swap1Xb":"0", "swap1Yb":"0"
 	, "swap2AltWeapon":"0", "swap2Item":"0", "swap2Xa":"0", "swap2Ya":"0", "swap2Xb":"0", "swap2Yb":"0"
 	, "profilesYesFlask":"0", "profilesFlask":"", "profilesYesUtility":"0", "profilesUtility":""}
@@ -37,7 +37,7 @@ for k, v in ["1","2","3","4","5"]
 }
 for k, v in ["1","2","3","4","5","6","7","8","9","10"]
 {
-	WR.Utility[v] := {"Enable":"0", "OnCD":"0", "Condition":"1", "Key":v, "GroupCD":"5000", "CD":"5000"
+	WR.Utility[v] := {"Enable":"0", "OnCD":"0", "Condition":"1", "StringResTrigger":"0", "Key":v, "GroupCD":"5000", "CD":"5000"
 	, "Group":"u"A_Index, "Slot":A_Index, "QS":"0", "Type":"Utility"
 	, "MainAttackOnly":"0", "MainAttack":"0", "SecondaryAttack":"0", "MainAttackRelease":"0", "SecondaryAttackRelease":"0", "Move":"0", "PopAll":"0", "Life":0, "ES":0, "Mana":0
 	, "Icon":"", "IconShown":"0", "IconSearch":"1", "IconArea":{}, "IconVar0":"0", "IconVar1":"0"
@@ -81,4 +81,3 @@ For k, name in ["perChar","Flask","Utility"]{
 	If !FileExist( A_ScriptDir "\save\profiles\" name "\Default.json")
 		Profile(name,"Save","Default")
 }
-

--- a/lib/gui/UtilityMenu.ahk
+++ b/lib/gui/UtilityMenu.ahk
@@ -72,7 +72,7 @@
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "Move xs+10   yp+20 Checked" WR.Utility[slot].Move , Enable
 
 		Gui, Utility%slot%: Add, GroupBox, center xs y+20 w120 h115, Trigger with Attack
-		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "MainAttackOnly xs+10 yp+20 Checked" WR.Utility[slot].MainAttackOnly, Main	Attack Only	
+		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "MainAttackOnly xs+10 yp+20 Checked" WR.Utility[slot].MainAttackOnly, Main	Attack Only
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "MainAttack xs+10 yp+20 Checked" WR.Utility[slot].MainAttack, Main
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "MainAttackRelease xs+10 y+5 Checked" WR.Utility[slot].MainAttackRelease, Main Release
 		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "SecondaryAttack xs+10   y+5 Checked" WR.Utility[slot].SecondaryAttack, Secondary
@@ -104,6 +104,9 @@
 		Gui, Utility%slot%: Add, Radio, % "vUtility" slot "Condition  x+5   yp-5 h22 Checked" (WR.Utility[slot].Condition==1?1:0), Any
 		Gui, Utility%slot%: Add, Radio, %                              " x+5 hp  yp Checked" (WR.Utility[slot].Condition==2?1:0), All
 
+		Gui, Utility%slot%: Add, GroupBox, center xs ys+155 w240 h50, Sample String and Resource
+		Gui, Utility%slot%: Add, Checkbox, % "vUtility" slot "StringResTrigger xs+10 yp+20 Checked" WR.Utility[slot].StringResTrigger, Sample String and Resource
+
 
 		Gui, Utility%slot%: show, AutoSize
 	}
@@ -123,10 +126,10 @@
 	Return
 
 	UtilitySaveValues:
-		for k, kind in ["Enable", "OnCD", "CD", "GroupCD", "Key", "MainAttackOnly", "MainAttack", "SecondaryAttack", "MainAttackRelease", "SecondaryAttackRelease", "PopAll", "Icon", "IconShown", "IconSearch", "IconArea", "Move", "Group", "Condition", "Curse", "Shock", "Bleed", "Freeze", "Ignite", "Poison"]
+		for k, kind in ["Enable", "OnCD", "CD", "GroupCD", "Key", "MainAttackOnly", "MainAttack", "SecondaryAttack", "MainAttackRelease", "SecondaryAttackRelease", "PopAll", "Icon", "IconShown", "IconSearch", "IconArea", "Move", "Group", "Condition", "StringResTrigger", "Curse", "Shock", "Bleed", "Freeze", "Ignite", "Poison"]
 			WR.Utility[which][kind] := Utility%which%%kind%
 		for k, kind in ["Life", "ES", "Mana"]
-			WR.Utility[which][kind] := Utility%which%%kind%_Slider.Slider_Value 
+			WR.Utility[which][kind] := Utility%which%%kind%_Slider.Slider_Value
 		for k, kind in ["IconVar1", "IconVar0"]
 			WR.Utility[which][kind] := Round(Utility%which%%kind% / 100,2)
 

--- a/lib/routine/MainLogic.ahk
+++ b/lib/routine/MainLogic.ahk
@@ -47,11 +47,11 @@ TGameTick(GuiCheck:=True){
 				Msg := "Paused while " . (!OnChar?"Not on Character":(OnChat?"Chat is Open":(OnMenu?"Passive/Atlas Menu Open":(OnInventory?"Inventory is Open":(OnStash?"Stash is Open":(OnVendor?"Vendor is Open":(OnDiv?"Divination Trade is Open":(OnLeft?"Left Panel is Open":(OnDelveChart?"Delve Chart is Open":(OnMetamorph?"Metamorph is Open":(YesXButtonFound?"X Button is Detected":"Error")))))))))))
 				If CheckTime("seconds",1,"StatusBar1")
 					SB_SetText(Msg, 1)
-				If (YesFillMetamorph) 
+				If (YesFillMetamorph)
 				{
 					If (Metamorph_Filled && (OnMetamorph || FindText( GameX + GameW * .5, GameY, GameX + GameW * .7, GameY + GameH * .3, 0, 0, XButtonStr )))
 						OnScreenMM := A_TickCount
-					Else If (OnMetamorph && !Metamorph_Filled 
+					Else If (OnMetamorph && !Metamorph_Filled
 					&& FindText( GameX + GameW * .5, GameY, GameX + GameW * .7, GameY + GameH * .3, 0, 0, XButtonStr ) )
 					{
 						Metamorph_Filled := True
@@ -140,12 +140,12 @@ TGameTick(GuiCheck:=True){
 				{
 					If (WR.cdExpires.Flask[A_Index] > A_TickCount) {
 						If (WR.Flask[A_Index].ResetCooldownAtHealthPercentage && Player.Percent.Life >= WR.Flask[A_Index].ResetCooldownAtHealthPercentageInput)
-						|| (WR.Flask[A_Index].ResetCooldownAtEnergyShieldPercentage && Player.Percent.ES >= WR.Flask[A_Index].ResetCooldownAtEnergyShieldPercentageInput) 
+						|| (WR.Flask[A_Index].ResetCooldownAtEnergyShieldPercentage && Player.Percent.ES >= WR.Flask[A_Index].ResetCooldownAtEnergyShieldPercentageInput)
 						|| (WR.Flask[A_Index].ResetCooldownAtManaPercentage && Player.Percent.Mana >= WR.Flask[A_Index].ResetCooldownAtManaPercentageInput) {
 							WR.cdExpires.Flask[A_Index] := 0
 							WR.cdExpires.Group[WR.Flask[A_Index].Group] := 0
 						}
-					} 
+					}
 					If (WR.cdExpires.Flask[A_Index] < A_TickCount) {
 						If ((WR.Flask[A_Index].Life && WR.Flask[A_Index].Life > Player.Percent.Life)
 						|| (WR.Flask[A_Index].ES && WR.Flask[A_Index].ES > Player.Percent.ES)
@@ -188,12 +188,13 @@ TGameTick(GuiCheck:=True){
 					If (WR.Utility[A_Index].Enable && WR.cdExpires.Utility[A_Index] <= A_TickCount)
 					{
 						If (NOT WR.Utility[A_Index].MainAttackOnly || ( WR.Utility[A_Index].MainAttackOnly && MainAttackPressedActive ))
-						{																									 
-							If (( WR.Utility[A_Index].OnCD )
+						{
+							If ((( WR.Utility[A_Index].OnCD )
 							|| ( WR.Utility[A_Index].ES && WR.Utility[A_Index].ES > Player.Percent.ES )
 							|| ( WR.Utility[A_Index].Life && WR.Utility[A_Index].Life > Player.Percent.Life )
-							|| ( WR.Utility[A_Index].Mana && WR.Utility[A_Index].Mana > Player.Percent.Mana ))
-								Trigger(WR.Utility[A_Index])
+							|| ( WR.Utility[A_Index].Mana && WR.Utility[A_Index].Mana > Player.Percent.Mana )) && (( !WR.Utility[A_Index].StringResTrigger )
+							|| ( WR.Utility[A_Index].StringResTrigger && (( WR.Utility[A_Index].IconShown && BuffIcon ) || ( !WR.Utility[A_Index].IconShown && !BuffIcon )))))
+							  Trigger(WR.Utility[A_Index])
 							Else If (WR.Utility[A_Index].Icon)
 							{
 								If (WR.Utility[A_Index].IconSearch == 1) ; Search Buff Area
@@ -204,8 +205,11 @@ TGameTick(GuiCheck:=True){
 									x1:=WR.Utility[A_Index].IconArea.X1, y1:=WR.Utility[A_Index].IconArea.Y1, x2:=WR.Utility[A_Index].IconArea.X2, y2:=WR.Utility[A_Index].IconArea.Y2
 
 								BuffIcon := FindText(x1, y1, x2, y2, WR.Utility[A_Index].IconVar1, WR.Utility[A_Index].IconVar0, WR.Utility[A_Index].Icon,0)
-								
-								If ((WR.Utility[A_Index].IconShown && BuffIcon) || (!WR.Utility[A_Index].IconShown && !BuffIcon))
+
+								If ((( WR.Utility[A_Index].IconShown && BuffIcon ) || ( !WR.Utility[A_Index].IconShown && !BuffIcon )) && ((!(WR.Utility[A_Index].StringResTrigger))
+								|| (WR.Utility[A_Index].StringResTrigger && (( WR.Utility[A_Index].ES && WR.Utility[A_Index].ES > Player.Percent.ES )
+								|| ( WR.Utility[A_Index].Life && WR.Utility[A_Index].Life > Player.Percent.Life )
+								|| ( WR.Utility[A_Index].Mana && WR.Utility[A_Index].Mana > Player.Percent.Mana ))))) 
 									Trigger(WR.Utility[A_Index],True)
 								Else
 									WR.cdExpires.Utility[A_Index] := A_TickCount + (WR.Utility[A_Index].IconShow ? 150 : WR.Utility[A_Index].CD)
@@ -258,7 +262,7 @@ TGameTick(GuiCheck:=True){
 			SB_SetText("No game found", 1)
 		If CheckTime("seconds",5,"StatusBar3")
 			SB_SetText("No game found", 3)
-	} 
+	}
 	Return
 }
 ; TDetonated - Detonate CD Timer

--- a/lib/routine/MainLogic.ahk
+++ b/lib/routine/MainLogic.ahk
@@ -206,10 +206,7 @@ TGameTick(GuiCheck:=True){
 
 								BuffIcon := FindText(x1, y1, x2, y2, WR.Utility[A_Index].IconVar1, WR.Utility[A_Index].IconVar0, WR.Utility[A_Index].Icon,0)
 
-								If ((( WR.Utility[A_Index].IconShown && BuffIcon ) || ( !WR.Utility[A_Index].IconShown && !BuffIcon )) && ((!(WR.Utility[A_Index].StringResTrigger))
-								|| (WR.Utility[A_Index].StringResTrigger && (( WR.Utility[A_Index].ES && WR.Utility[A_Index].ES > Player.Percent.ES )
-								|| ( WR.Utility[A_Index].Life && WR.Utility[A_Index].Life > Player.Percent.Life )
-								|| ( WR.Utility[A_Index].Mana && WR.Utility[A_Index].Mana > Player.Percent.Mana ))))) 
+								If ((( WR.Utility[A_Index].IconShown && BuffIcon ) || ( !WR.Utility[A_Index].IconShown && !BuffIcon )) && (!(WR.Utility[A_Index].StringResTrigger)))
 									Trigger(WR.Utility[A_Index],True)
 								Else
 									WR.cdExpires.Utility[A_Index] := A_TickCount + (WR.Utility[A_Index].IconShow ? 150 : WR.Utility[A_Index].CD)


### PR DESCRIPTION
I made a checkbox in utility and some small if statements so that you only trigger a sample string while below your set resource.

This is so that I can cast my val skill (count 1 of 2) when I get hit. It looks for the "1" on val Icon (bottom right spell bar) then casts that val if I am lacking in health. This is great with soul prevention builds!

My val can gain 2 charges. I cast second charge automatically on a timer, but want to save 1 for when it hurts.