### PR TITLE
Fix a typo

### DIFF
--- a/lib/CLASS_ItemScan.ahk
+++ b/lib/CLASS_ItemScan.ahk
@@ -1059,7 +1059,7 @@
 		}else if(indexOf(This.Prop.ItemClass,["Boots","Gloves","Amulets"])){
 			ILvLList := ILvLListBootsGlovesAmulets
 		}else if(indexOf(This.Prop.ItemClass,["Belts","Helmets","Quivers"])){
-			ILvLList := ILvLListBeltsHelmets
+			ILvLList := ILvLListBeltsHelmetsQuivers
 		}else if(indexOf(This.Prop.ItemClass,["Shields"])){
 			ILvLList := ILvLListShields
 		}else if(indexOf(This.Prop.ItemClass,["Body Armours"])){


### PR DESCRIPTION
The `ActualTierLife ` doesn't show for Belts and Helmets in iteminfo, changing this typo fixes it .