### PR TITLE
Fixed MMapItemQuantity not being picked up by Crafting

### DIFF
--- a/lib/routine/Crafting.ahk
+++ b/lib/routine/Crafting.ahk
@@ -353,6 +353,7 @@ ApplyCurrency(cname, x, y, Amount:=1){
 }
 ; MapRoll - Apply currency/reroll on maps based on select undesireable mods
 MapRoll(Method, x, y){
+	Global
 	MMQIgnore := False
 	If (!EnableMQQForMagicMap && Item.Prop.Rarity_Digit = 2)
 		MMQIgnore := True


### PR DESCRIPTION
Crafting was looking at Mods but ignoring Quantity Rarity and Pack Size because those variables were not accessible from the MapRoll function. Adding "Global" gives the function access to those variables and restores functionality.