### PR TITLE
Add exalt slamming, nightmare/originator map support, and 8-mod runnable sorting

### DIFF
--- a/lib/CLASS_ItemScan.ahk
+++ b/lib/CLASS_ItemScan.ahk
@@ -18,7 +18,7 @@
 			{
 				If (SectionKey = 1 && SVal ~= "Rarity:" || SVal ~= "Item Class:"){
 					This.Data.Blocks.NamePlate := SVal, This.Prop.IsItem := true
-				} Else If (SVal ~= "\(implicit\)$"){
+				} Else If (SVal ~= "\(implicit\)$" || SVal ~= "{ Implicit"){
 					This.Prop.HasImplicit := True
 					This.Data.Blocks.Implicit := SVal
 				} Else If (SVal ~= "{ Prefix" || SVal ~= "{ Suffix" || SVal ~= "{ Unique" || SVal ~= "^Pack Size:" ) {
@@ -38,7 +38,7 @@
 			{
 				If (SVal ~= "\.$" || SVal ~= "\?$" || SVal ~= """$")
 					This.Data.Blocks.FlavorText := SVal
-				Else If (SVal ~= "\(implicit\)$"){
+				Else If (SVal ~= "\(implicit\)$" || SVal ~= "{ Implicit"){
 					This.Prop.HasImplicit := True
 					This.Data.Blocks.Implicit := SVal
 				}
@@ -170,6 +170,7 @@
 			This.Prop.ItemClass := RxMatch1
 		If RegExMatch(This.Data.Blocks.NamePlate, "`am)Rarity: (.+)", RxMatch)
 			This.Prop.Rarity := RxMatch1
+
 		;Start NamePlate Parser
 		If (This.Prop.Rarity || This.Prop.ItemClass)
 		{
@@ -292,16 +293,21 @@
 			Else If (This.Prop.ItemClass = "Maps")
 			{
 				This.Prop.IsMap := True
-				; Deal with Blighted Map
-				If (InStr(This.Prop.ItemBase, "Blighted"))
-				{
-					This.Prop.IsBlightedMap := True
-					Prop.SpecialType := "Blighted Map"
-				}
-				Else If (InStr(This.Prop.ItemBase, "Blight-ravaged"))
+				; Blight-ravaged must be checked before Blighted (substring match)
+				If (InStr(This.Prop.ItemBase, "Blight-ravaged"))
 				{
 					This.Prop.IsBlightRavagedMap := True
-					Prop.SpecialType := "Blight-ravaged Map"
+					This.Prop.SpecialType := "Blight-ravaged Map"
+				}
+				Else If (InStr(This.Prop.ItemBase, "Blighted"))
+				{
+					This.Prop.IsBlightedMap := True
+					This.Prop.SpecialType := "Blighted Map"
+				}
+				Else If (InStr(This.Prop.ItemBase, "Nightmare"))
+				{
+					This.Prop.IsNightmareMap := True
+					This.Prop.SpecialType := "Nightmare Map"
 				}
 				Else
 				{
@@ -742,14 +748,18 @@
 		;End Prop Block Parser for General Items
 
 		;Start Prop Block Parser for Maps
-		;Every map has a Map Tier!
-		If (RegExMatch(This.Data.Blocks.NamePlate, "`am)^Map \(Tier " rxNum "\)",RxMatch))
+		If (This.Prop.IsMap)
 		{
-			This.Prop.Map_Tier := RxMatch1
-			If (RegExMatch(This.Data.Blocks.Properties, "`am)^Atlas Region: ([a-zA-Z0-9 ']+)",RxMatch))
-			{
-				This.Prop.Map_AtlasRegion := RxMatch1
-			}
+			; Extract tier from item name: "Map (Tier X)", "Blighted Map (Tier X)", etc.
+			If (RegExMatch(This.Prop.ItemBase, "\(Tier (\d+)\)", RxMatch))
+				This.Prop.Map_Tier := RxMatch1
+			Else If (RegExMatch(This.Prop.ItemName, "\(Tier (\d+)\)", RxMatch))
+				This.Prop.Map_Tier := RxMatch1
+			Else If (This.Prop.IsNightmareMap)
+				This.Prop.Map_Tier := 17
+			Else If (InStr(This.Prop.ItemBase, "Shaper Guardian"))
+				This.Prop.Map_Tier := 16
+
 			If (RegExMatch(This.Data.Blocks.Properties, "`am)^Item Quantity: \+"rxNum,RxMatch))
 			{
 				This.Prop.Map_Quantity := RxMatch1
@@ -762,10 +772,27 @@
 			{
 				This.Prop.Map_PackSize := RxMatch1
 			}
+			If RegExMatch(This.Data.Blocks.Properties, "`am)^More Maps: \+"rxNum, RxMatch)
+			{
+				This.Prop.Map_MapDropPercent := RxMatch1 * 1
+			}
+			If RegExMatch(This.Data.Blocks.Properties, "`am)^More Scarabs: \+"rxNum, RxMatch)
+			{
+				This.Prop.Map_ScarabDropPercent := RxMatch1 * 1
+			}
+			If RegExMatch(This.Data.Blocks.Properties, "`am)^More Currency: \+"rxNum, RxMatch)
+			{
+				This.Prop.Map_CurrencyDropPercent := RxMatch1 * 1
+			}
 			If (RegExMatch(This.Data.Blocks.Properties, "`am)^Delirium Reward Type:",RxMatch))
 			{
 				This.Prop.Map_Delirium := True
 			}
+			If (RegExmatch(This.Data.Blocks.Implicit, "`am)^Area is Influenced by the Originator",rxMatch))
+			{
+				This.Prop.Map_IsOriginatorMap := True
+			}
+
 			If (RegExMatch(This.Data.Blocks.Properties, "`am)^Quality: \+"rxNum,RxMatch))
 			{
 				This.Prop.Map_Quality := RxMatch1
@@ -773,6 +800,7 @@
 				;Set Quality to 0 if not in map prop (instead flagging as false)
 				This.Prop.Map_Quality := 0
 			}
+
 		}
 		;End Prop Block Parser for Maps
 
@@ -890,7 +918,12 @@
 		;Check if MapSum > Minimum Weight Settings
 		ConsiderMMQ := (This.Prop.RarityMagic && EnableMQQForMagicMap) || This.Prop.RarityRare
 		If (ConsiderMMQ) {
+			IsSpecialMap := This.Prop.Map_IsOriginatorMap || This.Prop.IsNightmareMap
 			MeetsMMQ := This.Prop.Map_Rarity >= MMapItemRarity && This.Prop.Map_PackSize >= MMapMonsterPackSize && This.Prop.Map_Quantity >= MMapItemQuantity
+				&& (!IsSpecialMap
+					|| ((MMapMoreMaps <= 0 || This.Prop.Map_MapDropPercent >= MMapMoreMaps)
+					&& (MMapMoreScarabs <= 0 || This.Prop.Map_ScarabDropPercent >= MMapMoreScarabs)
+					&& (MMapMoreCurrency <= 0 || This.Prop.Map_CurrencyDropPercent >= MMapMoreCurrency)))
 		} Else {
 			MeetsMMQ := True
 		}
@@ -903,6 +936,9 @@
 		}
 		If (This.Prop.Corrupted && (YesMapUnid && !This.Affix.Unidentified || !YesMapUnid) && !This.Prop.RarityUnique && (!GoodEnough || This.Prop.MapImpossibleMod)){
 			This.Prop.IsBrickedMap := True
+		}
+		If (This.Prop.Corrupted && This.Prop.AffixCount >= 8 && !This.Prop.RarityUnique && !This.Prop.MapImpossibleMod) {
+			This.Prop.Is8ModRunnableMap := True
 		}
 	}
 	MatchCraftingItemMods() {
@@ -2541,6 +2577,8 @@
 				sendstash := -2
 			Else
 				sendstash := StashTabBlight
+		} Else If (This.Prop.Is8ModRunnableMap && StashTabYes8ModRunnable) {
+			sendstash := StashTab8ModRunnable
 		} Else If (This.Prop.IsBrickedMap && StashTabYesBrickedMaps) {
 			sendstash := StashTabBrickedMaps
 		} Else If (This.Prop.IsMap && StashTabYesMap) {

--- a/lib/GLOBALS.ahk
+++ b/lib/GLOBALS.ahk
@@ -279,6 +279,8 @@ ft_ToolTip_Text_Part2=
 	StashTabYesLinked = Enable to send 6 or 5 Linked items to the assigned tab on the left
 	StashTabBrickedMaps = Assign the Stash tab for maps that have unwanted mods on them
 	StashTabYesBrickedMaps = Enable to send maps that have unwanted mods on them to the assigned tab on the left
+	StashTab8ModRunnable = Assign the Stash tab for corrupted 8-mod maps with no impossible mods
+	StashTabYes8ModRunnable = Enable to send corrupted 8-mod runnable maps to the assigned tab on the left
 	StashTabUniqueDump = Assign the Stash tab for Unique items`rIf Collection is enabled, this will be where overflow goes
 	StashTabYesUniqueDump = Enable to send Unique items to the assigned tab on the left`rIf Collection is enabled, this will be where overflow goes
 	StashTabUniqueRing = Assign the Stash tab for Unique Ring items`rIf Collection is enabled, this will be where overflow rings go
@@ -670,6 +672,8 @@ Global StashTabLinked := 1
 Global StashTabYesLinked := 1
 Global StashTabBrickedMaps := 1
 Global StashTabYesBrickedMaps := 1
+Global StashTab8ModRunnable := 1
+Global StashTabYes8ModRunnable := 0
 Global StashTabInfluencedItem := 1
 Global StashTabYesInfluencedItem := 1
 Global StashTabRunes := 1
@@ -843,7 +847,7 @@ Global stashSuffix1,stashSuffix2,stashSuffix3,stashSuffix4,stashSuffix5,stashSuf
 Global stashSuffixTab1,stashSuffixTab2,stashSuffixTab3,stashSuffixTab4,stashSuffixTab5,stashSuffixTab6,stashSuffixTab7,stashSuffixTab8,stashSuffixTab9
 
 ; Map Crafting Settings
-Global StartMapTier1,StartMapTier2,StartMapTier3,StartMapTier4,EndMapTier1,EndMapTier2,EndMapTier3,CraftingMapMethod1,CraftingMapMethod2,CraftingMapMethod3,EnableMQQForMagicMap,MMQorWeight,MMapItemRarity,MMapMonsterPackSize,MMapItemQuantity,MMapWeight,ForceMaxChisel
+Global StartMapTier1,StartMapTier2,StartMapTier3,StartMapTier4,EndMapTier1,EndMapTier2,EndMapTier3,CraftingMapMethod1,CraftingMapMethod2,CraftingMapMethod3,EnableMQQForMagicMap,MMQorWeight,MMapItemRarity,MMapMonsterPackSize,MMapItemQuantity,MMapWeight,MMapMoreMaps,MMapMoreScarabs,MMapMoreCurrency
 
 ; ItemInfo GUI
 Global PercentText1G1, PercentText1G2, PercentText1G3, PercentText1G4, PercentText1G5, PercentText1G6, PercentText1G7, PercentText1G8, PercentText1G9, PercentText1G10, PercentText1G11, PercentText1G12, PercentText1G13, PercentText1G14, PercentText1G15, PercentText1G16, PercentText1G17, PercentText1G18, PercentText1G19, PercentText1G20, PercentText1G21,

--- a/lib/SaveLoad.ahk
+++ b/lib/SaveLoad.ahk
@@ -201,6 +201,8 @@ readFromFile(){
 	IniRead, StashTabYesLinked, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesLinked, 1
 	IniRead, StashTabBrickedMaps, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabBrickedMaps, 1
 	IniRead, StashTabYesBrickedMaps, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesBrickedMaps, 1
+	IniRead, StashTab8ModRunnable, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTab8ModRunnable, 1
+	IniRead, StashTabYes8ModRunnable, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYes8ModRunnable, 0
 	IniRead, StashTabInfluencedItem, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabInfluencedItem, 1
 	IniRead, StashTabYesInfluencedItem, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabYesInfluencedItem, 1
 	IniRead, StashTabRunes, %A_ScriptDir%\save\Settings.ini, Stash Tab, StashTabRunes, 1

--- a/lib/gui/WR_Menu.ahk
+++ b/lib/gui/WR_Menu.ahk
@@ -141,6 +141,13 @@ WR_Menu(Function:="",Var*){
       Gui, Inventory: Add, Checkbox, gSaveStashTabs vStashTabYesBrickedMaps Checked%StashTabYesBrickedMaps% x+5 yp+4, Enable
 
       Gui, Inventory: Font, Bold s8 cBlack, Arial
+      Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , 8Mod Runnable
+      Gui, Inventory: Font,
+      Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
+      Gui, Inventory: Add, UpDown, Range1-99 x+0 yp hp gSaveStashTabs vStashTab8ModRunnable , %StashTab8ModRunnable%
+      Gui, Inventory: Add, Checkbox, gSaveStashTabs vStashTabYes8ModRunnable Checked%StashTabYes8ModRunnable% x+5 yp+4, Enable
+
+      Gui, Inventory: Font, Bold s8 cBlack, Arial
       Gui, Inventory: Add, GroupBox, w110 h50 xs yp+20 , Influenced Item
       Gui, Inventory: Font,
       Gui, Inventory: Add, Edit, Number w40 xp+6 yp+17
@@ -541,7 +548,7 @@ WR_Menu(Function:="",Var*){
 
       Gui, Crafting: Tab, Map Crafting
 
-      MapMethodList := "Disable|Transmutation+Augmentation|Alchemy|Alchemy+Vaal|Chisel+Alchemy|Chisel+Alchemy+Vaal|Binding|Chisel+Binding|Chisel+Binding+Vaal|Hybrid|Hybrid+Vaal|Binding+Vaal|Chisel+Hybrid|Chisel+Hybrid+Vaal|Chaos|Chisel+Chaos|Chisel+Chaos+Vaal"
+      MapMethodList := "Disable|Transmutation+Augmentation|Alchemy|Alchemy+Exalt|Alchemy+Exalt+Vaal|Alchemy+Vaal|Binding|Binding+Vaal|Hybrid|Hybrid+Vaal|Chaos|Chaos+Vaal"
       MapTierList := "1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16"
       MapSetValue := "1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|61|62|63|64|65|66|67|68|69|70|71|72|73|74|75|76|77|78|79|80|81|82|83|84|85|86|87|88|89|90|91|92|93|94|95|96|97|98|99|100"
       Gui, Crafting: Font, Bold s9 cBlack, Arial
@@ -620,11 +627,11 @@ WR_Menu(Function:="",Var*){
       Gui, Crafting: Add, UpDown, Range1-130 x+0 yp hp vMMapItemQuantity , %MMapItemQuantity%
       Gui, Crafting: Add, Text, x+10 yp+3 , Item Quantity
 
-      Gui, Crafting: Add, Edit, number limit2 xs+15 y+15 w50
+      Gui, Crafting: Add, Edit, number limit3 xs+15 y+15 w50
       Gui, Crafting: Add, UpDown, Range1-54 x+0 yp hp vMMapItemRarity , %MMapItemRarity%
       Gui, Crafting: Add, Text, x+10 yp+3 , Item Rarity
 
-      Gui, Crafting: Add, Edit, number limit2 xs+15 y+15 w50
+      Gui, Crafting: Add, Edit, number limit3 xs+15 y+15 w50
       Gui, Crafting: Add, UpDown, Range1-45 x+0 yp hp vMMapMonsterPackSize , %MMapMonsterPackSize%
       Gui, Crafting: Add, Text, x+10 yp+3 , Monster Pack Size
 
@@ -632,12 +639,28 @@ WR_Menu(Function:="",Var*){
       Gui, Crafting: Add, Checkbox, vMMQorWeight xs+15 y+5 Checked%MMQorWeight%, Match MMQ or Weight
 
       Gui, Crafting: Font, Bold s9 cBlack, Arial
-      Gui, Crafting: Add,GroupBox,Section w290 h90 x320 y210, Other Settings:
+      Gui, Crafting: Add,GroupBox,Section w200 h115 x320 y205, Originator / Nightmare:
+      Gui, Crafting: Font,
+      Gui, Crafting: Font,s8
+
+      Gui, Crafting: Add, Edit, number limit3 xs+15 yp+18 w50
+      Gui, Crafting: Add, UpDown, Range0-100 x+0 yp hp vMMapMoreMaps , %MMapMoreMaps%
+      Gui, Crafting: Add, Text, x+10 yp+3 , More Maps
+
+      Gui, Crafting: Add, Edit, number limit3 xs+15 y+15 w50
+      Gui, Crafting: Add, UpDown, Range0-100 x+0 yp hp vMMapMoreScarabs , %MMapMoreScarabs%
+      Gui, Crafting: Add, Text, x+10 yp+3 , More Scarabs
+
+      Gui, Crafting: Add, Edit, number limit3 xs+15 y+15 w50
+      Gui, Crafting: Add, UpDown, Range0-100 x+0 yp hp vMMapMoreCurrency , %MMapMoreCurrency%
+      Gui, Crafting: Add, Text, x+10 yp+3 , More Currency
+
+      Gui, Crafting: Font, Bold s9 cBlack, Arial
+      Gui, Crafting: Add,GroupBox,Section w290 h90 x320 y325, Other Settings:
       Gui, Crafting: Font,
       Gui, Crafting: Font,s8
       Gui, Crafting: Add, Checkbox, vHeistAlcNGo xs+10 ys+20 Checked%HeistAlcNGo%, Alchemy Contract and Blueprint?
       Gui, Crafting: Add, Checkbox, vMoveMapsToArea xs+10 ys+40 Checked%MoveMapsToArea%, Move Crafted Maps and Enhance Items to Map Area?
-      Gui, Crafting: Add, Checkbox, vForceMaxChisel xs+10 ys+60 Checked%ForceMaxChisel%, Force Maps to 20 Quality?
       Gui, Crafting: Font
 
       Gui, Crafting: Tab, Basic Crafting

--- a/lib/routine/Crafting.ahk
+++ b/lib/routine/Crafting.ahk
@@ -142,7 +142,7 @@ CraftingItem(){
 		Notify("Mod Selector Empty","You Need Select at Least 1 Affix on Mod Selector",4)
 		Log("[End]Item Crafting - Item Crafting Error","You Need Select at Least 1 Affix on Mod Selector")
 		Return
-	} 
+	}
 	If (ItemCraftingNumberPrefix == 0 && ItemCraftingNumberSuffix == 0 && ItemCraftingNumberCombination == 0) {
 		Notify("Affix Matcher Error","You Need Select at least one Prefix or Suffix or Combination",4)
 		Log("[End]Item Crafting - Item Crafting Error","You Need Select at least one Prefix or Suffix or Combination")
@@ -189,8 +189,15 @@ CraftingMaps(){
 	ShooMouse(), GuiStatus(), ClearNotifications()
 	; Ignore Slot
 	BlackList := Array_DeepClone(BlackList_Default)
-	WR.data.Counts := CountCurrency(["Alchemy","Binding","Transmutation","Scouring","Vaal","Chisel","Chaos","Augmentation"])
-	; MsgBoxVals(WR.data.Counts)
+	CurrencyList := ["Alchemy","Binding","Transmutation","Scouring","Vaal","Chaos","Augmentation"]
+	For idx, m in [CraftingMapMethod1, CraftingMapMethod2, CraftingMapMethod3] {
+		If (m ~= "Exalt") {
+			CurrencyList.Push("Exalted")
+			Break
+		}
+	}
+	WR.data.Counts := CountCurrency(CurrencyList)
+;	MsgBoxVals(WR.data.Counts)
 	MapList := {}
 	; Start Scan on Inventory
 	For C, GridX in InventoryGridX
@@ -216,10 +223,9 @@ CraftingMaps(){
 			mapCraftingMethod := getMapCraftingMethod()
 			If (Item.Affix["Unidentified"]&&YesIdentify)
 			{
-				If ( (Item.Prop.IsMap || Item.Prop.IsBlightedMap) 
+				If ( (Item.Prop.IsMap || Item.Prop.IsBlightedMap)
 					&& (!YesMapUnid
-							|| ( Item.Prop.RarityMagic && mapCraftingMethod ~= "(Alchemy|Hybrid|Binding|Chaos)" )
-							|| ( Item.Affix.Unidentified && mapCraftingMethod ~= "Chisel" && Item.Prop.Map_Quality < 20 )	)
+					|| ( Item.Prop.RarityMagic && mapCraftingMethod ~= "(Alchemy|Hybrid|Binding|Chaos)" ) )
 					&& !Item.Prop.Corrupted)
 				{
 					WisdomScroll(Grid.X,Grid.Y)
@@ -234,28 +240,12 @@ CraftingMaps(){
 			;Crafting Map Script
 			If ((Item.Prop.IsMap || Item.Prop.IsBlightedMap) && !Item.Prop.Corrupted && !Item.Prop.RarityUnique)
 			{
-				If (mapCraftingMethod ~= "Chisel") {
-					qualityPerChisel := Item.Prop.Map_Tier > 10 ? 5 
-					:	Item.Prop.Map_Tier > 5 ? 10 
-					:	Item.Prop.Map_Tier >= 1 ? 20 
-					: 1
-					numberChisel := 0
-
-					If (Item.Prop.Map_Quality < 20) {
-						numberChisel := ForceMaxChisel ? Ceil((20 - Item.Prop.Map_Quality)/qualityPerChisel) : (20 - Item.Prop.Map_Quality)//qualityPerChisel
-					}
-				
-					If !ApplyCurrency("Chisel",Grid.X,Grid.Y,numberChisel)
-						Return False
-				}
-
 				If (!Item.Prop.RarityNormal)
 				{
-					If ( (Item.Prop.RarityMagic && mapCraftingMethod == "Transmutation+Augmentation") 
-						|| (Item.Prop.RarityRare && (mapCraftingMethod == "Transmutation+Augmentation" || mapCraftingMethod ~= "(^Alchemy$|^Binding$|^Hybrid$|^Chaos$)")) 
-						|| (Item.Prop.RarityRare && Item.Prop.Quality >= 16 && mapCraftingMethod ~= "(Alchemy|Binding|Hybrid|Chaos)") )
+					If ( (Item.Prop.RarityMagic && mapCraftingMethod == "Transmutation+Augmentation")
+						|| (Item.Prop.RarityRare && (mapCraftingMethod == "Transmutation+Augmentation" || mapCraftingMethod ~= "(^Alchemy|^Binding|^Hybrid|^Chaos)")) )
 					{
-						If (!Item.Prop.MapKeepFlag)
+						If (!Item.Prop.MapKeepFlag || (mapCraftingMethod ~= "Exalt" && Item.Prop.AffixCount < 6))
 							MapRoll(mapCraftingMethod, Grid.X,Grid.Y)
 						If (mapCraftingMethod ~= "Vaal$")
 							ApplyCurrency("Vaal",Grid.X,Grid.Y)
@@ -449,10 +439,12 @@ MapRoll(Method, x, y){
 		If !ApplyCurrency("Augmentation",x,y)
 			Return False
 	}
+	NeedsExalt := (Method ~= "Exalt")
 	BelowRarity := Item.Prop.Map_Rarity < MMapItemRarity
 	BelowPackSize := Item.Prop.Map_PackSize < MMapMonsterPackSize
 	BelowQuantity := Item.Prop.Map_Quantity < MMapItemQuantity
 	; Corrupted White Maps can break the function without !Item.Prop.Corrupted in loop
+	Loop { ; Outer loop: allows restart if exalt ruins the map
 	While (!Item.Affix["Unidentified"] && !Item.Prop.Corrupted && Item.Prop.MapRerollFlag)
 	{
 		If (!RunningToggle) {
@@ -470,6 +462,9 @@ MapRoll(Method, x, y){
 			, "Minimum Map Qualities: "(Item.Prop.Map_Rarity < MMapItemRarity?" Below " MMapItemRarity " Rarity: " Item.Prop.Map_Rarity ",": " Adequate Rarity,")
 			. (Item.Prop.Map_PackSize < MMapMonsterPackSize?" Below " MMapMonsterPackSize " PackSize: " Item.Prop.Map_PackSize ",": " Adequate PackSize,")
 			. (Item.Prop.Map_Quantity < MMapItemQuantity?" Below " MMapItemQuantity " Quantity: " Item.Prop.Map_Quantity : " Adequate Quantity")
+			. ((Item.Prop.Map_IsOriginatorMap || Item.Prop.IsNightmareMap) && MMapMoreMaps > 0 && Item.Prop.Map_MapDropPercent < MMapMoreMaps?" Below " MMapMoreMaps " More Maps: " Item.Prop.Map_MapDropPercent ",": "")
+			. ((Item.Prop.Map_IsOriginatorMap || Item.Prop.IsNightmareMap) && MMapMoreScarabs > 0 && Item.Prop.Map_ScarabDropPercent < MMapMoreScarabs?" Below " MMapMoreScarabs " More Scarabs: " Item.Prop.Map_ScarabDropPercent ",": "")
+			. ((Item.Prop.Map_IsOriginatorMap || Item.Prop.IsNightmareMap) && MMapMoreCurrency > 0 && Item.Prop.Map_CurrencyDropPercent < MMapMoreCurrency?" Below " MMapMoreCurrency " More Currency: " Item.Prop.Map_CurrencyDropPercent : "")
 			,JSON.Dump(Item) )
 		; Scouring or Alteration
 		If !ApplyCurrency(crname, x, y)
@@ -485,6 +480,28 @@ MapRoll(Method, x, y){
 		BelowRarity := Item.Prop.Map_Rarity < MMapItemRarity
 		BelowPackSize := Item.Prop.Map_PackSize < MMapMonsterPackSize
 		BelowQuantity := Item.Prop.Map_Quantity < MMapItemQuantity
+
+		BelowAdditionalMaps := (Item.Prop.Map_IsOriginatorMap || Item.Prop.IsNightmareMap) && MMapMoreMaps > 0 && Item.Prop.Map_MapDropPercent < MMapMoreMaps
+		BelowScarabDropPercent := (Item.Prop.Map_IsOriginatorMap || Item.Prop.IsNightmareMap) && MMapMoreScarabs > 0 && Item.Prop.Map_ScarabDropPercent < MMapMoreScarabs
+		BelowCurrencyDropPercent := (Item.Prop.Map_IsOriginatorMap || Item.Prop.IsNightmareMap) && MMapMoreCurrency > 0 && Item.Prop.Map_CurrencyDropPercent < MMapMoreCurrency
+
+	}
+	; Exalt phase: only if method requires it, map passed all checks, and has open mod slots
+	If (!NeedsExalt || !Item.Prop.MapKeepFlag || Item.Prop.AffixCount >= 6 || !RunningToggle)
+		Break
+	; Map is good but has <6 mods - apply Exalted Orbs to fill slots
+	While (Item.Prop.AffixCount < 6 && RunningToggle) {
+		If !ApplyCurrency("Exalted", x, y)
+			Return False
+		; ApplyCurrency calls ClipItem which re-evaluates MapKeepFlag/MapRerollFlag
+		If (Item.Prop.MapRerollFlag) {
+			Break
+		}
+	}
+	; If map is still good after exalts, we're done
+	If (Item.Prop.MapKeepFlag)
+		Break
+	; Exalt ruined the map - outer loop restarts: inner while will scour + reroll
 	}
 	Log("Crafting","Map crafting resulted in a"
 		. (Item.Prop.RarityNormal?" Normal Map":"")
@@ -495,6 +512,10 @@ MapRoll(Method, x, y){
 		, "Map is" (Item.Prop.Map_Rarity < MMapItemRarity?" Below " MMapItemRarity " Rarity: " Item.Prop.Map_Rarity ",":" Adequate Rarity,")
 		. (Item.Prop.Map_PackSize < MMapMonsterPackSize?" Below " MMapMonsterPackSize " PackSize: " Item.Prop.Map_PackSize ",":" Adequate PackSize,")
 		. (Item.Prop.Map_Quantity < MMapItemQuantity?" Below " MMapItemQuantity " Quantity: " Item.Prop.Map_Quantity :" Adequate Quantity")
+		. (Item.Prop.Map_MapDropPercent?" More Maps: " Item.Prop.Map_MapDropPercent (MMapMoreMaps > 0 ? "/" MMapMoreMaps : "") ",": "")
+		. (Item.Prop.Map_ScarabDropPercent?" More Scarabs: " Item.Prop.Map_ScarabDropPercent (MMapMoreScarabs > 0 ? "/" MMapMoreScarabs : "") ",": "")
+		. (Item.Prop.Map_CurrencyDropPercent?" More Currency: " Item.Prop.Map_CurrencyDropPercent (MMapMoreCurrency > 0 ? "/" MMapMoreCurrency : "") : "")
+		. (Item.Prop.Map_IsOriginatorMap?" Originator Map " : "")
 		,JSON.Dump(Item) )
 	Return 1
 }


### PR DESCRIPTION
- Add Exalted Orb slamming for maps (Alchemy+Exalt, Alchemy+Exalt+Vaal) Fills empty mod slots to 6, restarts roll if exalt ruins the map
- Detect Nightmare and Originator maps with proper tier handling
- Parse More Maps/More Scarabs/More Currency properties
- Add minimum thresholds for special map quant in crafting loop
- Detect and route corrupted 8-mod runnable maps to dedicated stash tab
- Add GUI controls for Originator/Nightmare settings and 8-mod stash tab
- Remove obsolete Chisel-based crafting methods

I'll provide a PR for the new uber tier map mods, too so all map rolling related things should then reflect latest 3.28 version